### PR TITLE
[codex] fix row level security raw predicates

### DIFF
--- a/.changeset/fix-rls-true-predicates.md
+++ b/.changeset/fix-rls-true-predicates.md
@@ -1,0 +1,5 @@
+---
+"@nest-boot/row-level-security": patch
+---
+
+Wrap raw `using` and `withCheck` policy expressions when generating PostgreSQL policy SQL so values like `true` produce valid predicates.

--- a/apps/docs/content/docs/tutorial/row-level-security.mdx
+++ b/apps/docs/content/docs/tutorial/row-level-security.mdx
@@ -78,6 +78,8 @@ For custom policy logic, provide explicit SQL predicates:
 })
 ```
 
+Explicit `using` and `withCheck` expressions may be written as raw SQL fragments such as `true` or `"is_public" = true`; generated migrations wrap them as PostgreSQL policy predicates.
+
 ## Generate Migrations
 
 With `RowLevelSecurityMigrationGenerator` configured, MikroORM migration generation includes RLS SQL for policies discovered from entity metadata. Generated migrations extend `RowLevelSecurityMigration`, which adds the shared `app.get_context(...)` helper, database roles, grants, and policy DDL.

--- a/apps/docs/content/docs/tutorial/row-level-security.zh-Hans.mdx
+++ b/apps/docs/content/docs/tutorial/row-level-security.zh-Hans.mdx
@@ -78,6 +78,8 @@ export class File {
 })
 ```
 
+显式的 `using` 和 `withCheck` 可以写成 `true` 或 `"is_public" = true` 这样的裸 SQL 片段；生成迁移时会把它们包装成 PostgreSQL policy 谓词。
+
 ## 生成迁移
 
 配置 `RowLevelSecurityMigrationGenerator` 后，MikroORM 生成迁移时会根据实体元数据中的策略写入 RLS SQL。生成的迁移会继承 `RowLevelSecurityMigration`，用于添加共享的 `app.get_context(...)` 函数、数据库角色、授权和策略 DDL。

--- a/packages/row-level-security/src/interfaces/policy-options.interface.ts
+++ b/packages/row-level-security/src/interfaces/policy-options.interface.ts
@@ -13,9 +13,9 @@ export interface PolicyOptions {
   property?: string;
   /** Row-level security context key read through `app.get_context`. */
   context?: string;
-  /** Explicit `USING` expression. Overrides the generated predicate when provided. */
+  /** Explicit `USING` expression. Overrides the generated predicate when provided. Raw expressions are parenthesized in generated SQL. */
   using?: string;
-  /** Explicit `WITH CHECK` expression. Overrides the generated predicate when provided. */
+  /** Explicit `WITH CHECK` expression. Overrides the generated predicate when provided. Raw expressions are parenthesized in generated SQL. */
   withCheck?: string;
   /** Database roles to which the policy applies. Empty or omitted means no role restriction. */
   roles?: string[];

--- a/packages/row-level-security/src/interfaces/policy-sql-options.interface.ts
+++ b/packages/row-level-security/src/interfaces/policy-sql-options.interface.ts
@@ -13,9 +13,9 @@ export interface PolicySqlOptions {
   mode?: PolicyMode;
   /** PostgreSQL command covered by the policy. Defaults to {@link PolicyCommand.ALL}. */
   command?: PolicyCommand;
-  /** SQL expression emitted as the policy `USING` predicate. */
+  /** SQL expression emitted as the policy `USING` predicate. Raw expressions are parenthesized in generated SQL. */
   using?: string;
-  /** SQL expression emitted as the policy `WITH CHECK` predicate. */
+  /** SQL expression emitted as the policy `WITH CHECK` predicate. Raw expressions are parenthesized in generated SQL. */
   withCheck?: string;
   /** Database roles to which the generated policy applies. */
   roles?: string[];

--- a/packages/row-level-security/src/row-level-security-migration-generator.spec.ts
+++ b/packages/row-level-security/src/row-level-security-migration-generator.spec.ts
@@ -624,7 +624,7 @@ describe("RowLevelSecurityMigrationGenerator", () => {
     expect(file).toContain("create policy workspace_member_user_select_policy");
     expect(file).toContain("create policy removed_workspace_member_policy");
     expect(file).toContain("create policy removed_workspace_member_policy on");
-    expect(file).toContain("for select to authenticated using true");
+    expect(file).toContain("for select to authenticated using (true)");
   });
 
   it("recreates policies when an existing policy changes content", () => {
@@ -660,7 +660,7 @@ describe("RowLevelSecurityMigrationGenerator", () => {
     expect(file).toContain(
       "using ((select app.get_context('user_id', null::bigint)) = \"user_id\")",
     );
-    expect(file).toContain("for select to authenticated using false");
+    expect(file).toContain("for select to authenticated using (false)");
   });
 
   it("matches create table statements for non-public schemas and collection names", () => {
@@ -678,7 +678,7 @@ describe("RowLevelSecurityMigrationGenerator", () => {
     });
 
     expect(file).toContain(
-      'this.addSql(`create policy audit_log_select_policy on "app"."audit_log" as permissive for select using true;`);',
+      'this.addSql(`create policy audit_log_select_policy on "app"."audit_log" as permissive for select using (true);`);',
     );
   });
 

--- a/packages/row-level-security/src/utils/create-policy-up-sql-statements.ts
+++ b/packages/row-level-security/src/utils/create-policy-up-sql-statements.ts
@@ -146,7 +146,7 @@ function getPolicyPredicateSql(
   const fragments: string[] = [];
 
   if (command !== PolicyCommand.INSERT && predicates.using) {
-    fragments.push(`using ${predicates.using}`);
+    fragments.push(`using ${createPredicateExpressionSql(predicates.using)}`);
   }
 
   if (
@@ -154,8 +154,18 @@ function getPolicyPredicateSql(
     command !== PolicyCommand.DELETE &&
     predicates.withCheck
   ) {
-    fragments.push(`with check ${predicates.withCheck}`);
+    fragments.push(
+      `with check ${createPredicateExpressionSql(predicates.withCheck)}`,
+    );
   }
 
   return fragments.join(" ");
+}
+
+function createPredicateExpressionSql(expression: string) {
+  return isParenthesizedExpression(expression) ? expression : `(${expression})`;
+}
+
+function isParenthesizedExpression(expression: string) {
+  return expression.startsWith("(") && expression.endsWith(")");
 }

--- a/packages/row-level-security/src/utils/policy-migration-sql.spec.ts
+++ b/packages/row-level-security/src/utils/policy-migration-sql.spec.ts
@@ -103,6 +103,21 @@ describe("policy migration SQL", () => {
     );
   });
 
+  it("wraps raw using predicates in parentheses", () => {
+    const statements = createPolicyUpSqlStatements({
+      schemaName: "public",
+      tableName: "user",
+      policyName: "user_select_authenticated_policy",
+      command: PolicyCommand.SELECT,
+      using: "true",
+      roles: ["authenticated"],
+    });
+
+    expect(statements).toContain(
+      'create policy user_select_authenticated_policy on "public"."user" as permissive for select to authenticated using (true);',
+    );
+  });
+
   it("generates table grants for explicit policy roles", () => {
     const statements = createPolicyUpSqlStatements({
       schemaName: "public",
@@ -271,7 +286,7 @@ describe("policy migration SQL", () => {
     });
 
     expect(statements[2]).toBe(
-      'create policy workspace_member_insert_policy on "public"."workspace_member" as permissive for insert with check true;',
+      'create policy workspace_member_insert_policy on "public"."workspace_member" as permissive for insert with check (true);',
     );
   });
 


### PR DESCRIPTION
## Summary

- Wrap raw row-level-security `using` and `withCheck` expressions when generating PostgreSQL policy SQL.
- Keep already-parenthesized predicates unchanged to avoid unnecessary migration churn.
- Document that raw SQL fragments such as `true` are supported and add a patch changeset.

## Validation

- `pnpm --filter @nest-boot/row-level-security exec jest src/utils/policy-migration-sql.spec.ts --runInBand`
- `pnpm --filter @nest-boot/row-level-security exec jest src/row-level-security-migration-generator.spec.ts src/row-level-security-migration.spec.ts --runInBand`
- `DB_URL=postgres://postgres:secret@localhost:5432/postgres pnpm --filter @nest-boot/row-level-security exec jest --runInBand`
- `pnpm --filter @nest-boot/row-level-security build`
- `pnpm --filter @nest-boot/row-level-security lint`
- `pnpm --filter @nest-boot/docs lint`
- `pnpm --filter @nest-boot/docs types:check`
- `git diff --check`

Closes #234
