### PR TITLE
fix: row level security policy diff detection

### DIFF
--- a/.changeset/tall-boats-hug.md
+++ b/.changeset/tall-boats-hug.md
@@ -1,0 +1,5 @@
+---
+"@nest-boot/row-level-security": patch
+---
+
+Detect row-level-security policy-only migration changes, including policy context updates when table schemas are unchanged.

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,6 +14,10 @@ jobs:
     name: Lint
     uses: ./.github/workflows/lint.yml
 
+  typedoc:
+    name: TypeDoc
+    uses: ./.github/workflows/typedoc.yml
+
   test:
     name: Test
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -1,37 +1,11 @@
-name: Release
+name: TypeDoc
 
-on:
-  push:
-    branches:
-      - master
-
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+on: workflow_call
 
 jobs:
-  build:
-    name: Build
-    uses: ./.github/workflows/build.yml
-
-  lint:
-    name: Lint
-    uses: ./.github/workflows/lint.yml
-
   typedoc:
     name: TypeDoc
-    uses: ./.github/workflows/typedoc.yml
-
-  test:
-    name: Test
-    uses: ./.github/workflows/test.yml
-
-  release:
-    needs: [build, lint, typedoc, test]
-    name: Release
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write
-      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -65,12 +39,5 @@ jobs:
       - name: Build
         run: pnpm build:packages --no-cache
 
-      - name: Create Release Pull Request or Publish to npm
-        id: changesets
-        uses: changesets/action@v1
-        with:
-          version: pnpm version-packages
-          publish: pnpm publish-packages
-          createGithubReleases: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: TypeDoc
+        run: pnpm typedoc:check

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-node_modules/.bin/lint-staged
+pnpm commit:check

--- a/apps/docs/content/docs/tutorial/row-level-security.mdx
+++ b/apps/docs/content/docs/tutorial/row-level-security.mdx
@@ -13,16 +13,18 @@ pnpm add @nest-boot/row-level-security @nest-boot/request-context @mikro-orm/pos
 
 ## Configure MikroORM
 
-Use `RowLevelSecurityDriver` as the MikroORM PostgreSQL driver and `RowLevelSecurityMigrationGenerator` as the migration generator:
+Use `RowLevelSecurityDriver` as the MikroORM PostgreSQL driver, `RowLevelSecurityMigrator` as the migrator extension, and `RowLevelSecurityMigrationGenerator` as the migration generator:
 
 ```typescript
 import {
   RowLevelSecurityDriver,
   RowLevelSecurityMigrationGenerator,
+  RowLevelSecurityMigrator,
 } from "@nest-boot/row-level-security";
 
 export default {
   driver: RowLevelSecurityDriver,
+  extensions: [RowLevelSecurityMigrator],
   migrations: {
     generator: RowLevelSecurityMigrationGenerator,
   },
@@ -83,6 +85,7 @@ Explicit `using` and `withCheck` expressions may be written as raw SQL fragments
 ## Generate Migrations
 
 With `RowLevelSecurityMigrationGenerator` configured, MikroORM migration generation includes RLS SQL for policies discovered from entity metadata. Generated migrations extend `RowLevelSecurityMigration`, which adds the shared `app.get_context(...)` helper, database roles, grants, and policy DDL.
+`RowLevelSecurityMigrator` lets `migration:create` detect policy-only changes, such as changing a policy `context` while the table schema stays unchanged.
 
 ```bash
 pnpm mikro-orm migration:create

--- a/apps/docs/content/docs/tutorial/row-level-security.mdx
+++ b/apps/docs/content/docs/tutorial/row-level-security.mdx
@@ -27,9 +27,12 @@ export default {
   extensions: [RowLevelSecurityMigrator],
   migrations: {
     generator: RowLevelSecurityMigrationGenerator,
+    snapshot: false,
   },
 };
 ```
+
+Policy-only migration detection currently requires `migrations.snapshot: false`. With MikroORM snapshot mode enabled, generated policy migrations are not represented in the schema snapshot, so running `migration:create` again before applying the generated migration can emit the same policy diff again. Keep snapshots disabled until snapshot-backed RLS policy tracking is supported.
 
 The driver applies RLS only when a `RequestContext` is active and the current context has row-level security values set through `RowLevelSecurity`. If no row-level security role or context values are present, it delegates to MikroORM unchanged unless it needs to clear RLS state previously applied to the same transaction.
 

--- a/apps/docs/content/docs/tutorial/row-level-security.zh-Hans.mdx
+++ b/apps/docs/content/docs/tutorial/row-level-security.zh-Hans.mdx
@@ -27,9 +27,12 @@ export default {
   extensions: [RowLevelSecurityMigrator],
   migrations: {
     generator: RowLevelSecurityMigrationGenerator,
+    snapshot: false,
   },
 };
 ```
+
+策略差异检测目前要求 `migrations.snapshot: false`。开启 MikroORM snapshot 模式时，生成的 policy migration 不会写入 schema snapshot；如果在应用该迁移之前再次运行 `migration:create`，可能会再次生成同一个 policy diff。在支持基于 snapshot 的 RLS policy tracking 前，请保持关闭 snapshot。
 
 驱动只会在 `RequestContext` 处于活动状态，并且当前上下文中通过 `RowLevelSecurity` 设置了行级安全值时应用 RLS。如果没有设置 RLS role 或 context 值，它会按 MikroORM 原始逻辑执行；但如果同一个事务之前已经应用过 RLS 状态，驱动会先清理这些状态。
 

--- a/apps/docs/content/docs/tutorial/row-level-security.zh-Hans.mdx
+++ b/apps/docs/content/docs/tutorial/row-level-security.zh-Hans.mdx
@@ -13,16 +13,18 @@ pnpm add @nest-boot/row-level-security @nest-boot/request-context @mikro-orm/pos
 
 ## 配置 MikroORM
 
-将 `RowLevelSecurityDriver` 配置为 MikroORM 的 PostgreSQL 驱动，并将 `RowLevelSecurityMigrationGenerator` 配置为迁移生成器：
+将 `RowLevelSecurityDriver` 配置为 MikroORM 的 PostgreSQL 驱动，将 `RowLevelSecurityMigrator` 配置为迁移扩展，并将 `RowLevelSecurityMigrationGenerator` 配置为迁移生成器：
 
 ```typescript
 import {
   RowLevelSecurityDriver,
   RowLevelSecurityMigrationGenerator,
+  RowLevelSecurityMigrator,
 } from "@nest-boot/row-level-security";
 
 export default {
   driver: RowLevelSecurityDriver,
+  extensions: [RowLevelSecurityMigrator],
   migrations: {
     generator: RowLevelSecurityMigrationGenerator,
   },
@@ -83,6 +85,7 @@ export class File {
 ## 生成迁移
 
 配置 `RowLevelSecurityMigrationGenerator` 后，MikroORM 生成迁移时会根据实体元数据中的策略写入 RLS SQL。生成的迁移会继承 `RowLevelSecurityMigration`，用于添加共享的 `app.get_context(...)` 函数、数据库角色、授权和策略 DDL。
+`RowLevelSecurityMigrator` 会让 `migration:create` 检测只有策略变化、表结构不变的场景，例如只修改 policy 的 `context`。
 
 ```bash
 pnpm mikro-orm migration:create

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "node": ">=24.0.0"
   },
   "scripts": {
+    "commit:check": "lint-staged && pnpm docs:check",
     "cz": "cz",
     "prepare": "husky install",
     "build": "turbo run build",
@@ -21,8 +22,10 @@
     "test": "jest",
     "test:cov": "jest --coverage",
     "format": "prettier --check --write \"**/*.{ts,tsx,md}\"",
+    "docs:check": "pnpm build:packages && pnpm typedoc:check",
     "docs:generate": "typedoc --treatValidationWarningsAsErrors && rimraf apps/docs/content/docs/api/index.mdx",
     "lint": "turbo run lint",
+    "typedoc:check": "typedoc --treatValidationWarningsAsErrors --emit none",
     "changeset": "changeset",
     "version-packages": "changeset version && pnpm install --no-frozen-lockfile && pnpm format",
     "publish-packages": "pnpm build:packages && changeset publish --filter=./packages/*"

--- a/packages/row-level-security/src/index.spec.ts
+++ b/packages/row-level-security/src/index.spec.ts
@@ -14,6 +14,7 @@ describe("row level security package exports", () => {
     expect(rowLevelSecurity.RowLevelSecurityDriver).toBeDefined();
     expect(rowLevelSecurity.RowLevelSecurityMigration).toBeDefined();
     expect(rowLevelSecurity.RowLevelSecurityMigrationGenerator).toBeDefined();
+    expect(rowLevelSecurity.RowLevelSecurityMigrator).toBeDefined();
     expect(rowLevelSecurity.createPolicyUpSqlStatements).toBeDefined();
   });
 

--- a/packages/row-level-security/src/index.ts
+++ b/packages/row-level-security/src/index.ts
@@ -7,4 +7,5 @@ export * from "./row-level-security";
 export * from "./row-level-security-driver";
 export * from "./row-level-security-migration";
 export * from "./row-level-security-migration-generator";
+export * from "./row-level-security-migrator";
 export * from "./utils";

--- a/packages/row-level-security/src/row-level-security-migration-generator.spec.ts
+++ b/packages/row-level-security/src/row-level-security-migration-generator.spec.ts
@@ -3,6 +3,7 @@ import { TSMigrationGenerator } from "@mikro-orm/migrations";
 import { Policy } from "./decorators/policy.decorator";
 import { PolicyCommand } from "./enums/policy-command.enum";
 import { RowLevelSecurityMigrationGenerator } from "./row-level-security-migration-generator";
+import { RowLevelSecurityMigrator } from "./row-level-security-migrator";
 
 @Policy({
   name: "workspace_member_user_select_policy",
@@ -29,6 +30,15 @@ class WorkspaceMemberWithMultiplePolicies {}
   context: "user_id",
 })
 class WorkspaceMemberWithGeneratedPolicy {}
+
+@Policy({
+  name: "workspace_member_workspace_select_policy",
+  command: PolicyCommand.SELECT,
+  property: "workspace",
+  context: "workspace_id",
+  roles: ["authenticated"],
+})
+class WorkspaceMemberWithWorkspaceContextPolicy {}
 
 @Policy({
   name: "audit_log_select_policy",
@@ -257,6 +267,48 @@ describe("RowLevelSecurityMigrationGenerator", () => {
       "/tmp/Migration.ts",
     ]);
     expect(superGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it("detects pending policy-only changes from existing database policies", async () => {
+    const execute = jest.fn((_sql: string) =>
+      Promise.resolve([
+        {
+          policy_name: "workspace_member_workspace_select_policy",
+          schema_name: "public",
+          table_name: "workspace_member",
+          permissive: true,
+          command: "r",
+          qual: `((select app.get_context('tenant_id', null::bigint)) = "workspace_id")`,
+          with_check: null,
+          roles: ["authenticated"],
+        },
+      ]),
+    );
+    const generator = createGenerator(
+      [
+        {
+          class: WorkspaceMemberWithWorkspaceContextPolicy,
+          tableName: "workspace_member",
+          properties: {
+            workspace: {
+              fieldNames: ["workspace_id"],
+              columnTypes: ["bigint"],
+            },
+          },
+        },
+      ],
+      {
+        getConnection: () => ({
+          execute,
+        }),
+      },
+    );
+
+    await expect(
+      generator.hasPendingPolicyChanges({ up: [], down: [] }),
+    ).resolves.toBe(true);
+    expect((generator as any).existingPolicyDefinitions).toBeUndefined();
+    expect((generator as any).currentPolicyDefinitions).toBeUndefined();
   });
 
   it("does not recreate policies for unrelated schema changes without a database connection", async () => {
@@ -775,6 +827,85 @@ describe("RowLevelSecurityMigrationGenerator", () => {
     expect(RowLevelSecurityMigrationGenerator.prototype).toBeInstanceOf(
       TSMigrationGenerator,
     );
+  });
+});
+
+describe("RowLevelSecurityMigrator", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("creates a migration when only row-level-security policies changed", async () => {
+    const diff = { up: [], down: [] };
+    const generator = createGenerator([]);
+    const hasPendingPolicyChanges = jest
+      .spyOn(generator, "hasPendingPolicyChanges")
+      .mockResolvedValue(true);
+    const generate = jest
+      .spyOn(generator, "generate")
+      .mockResolvedValue(["migration-file", "Migration.ts"]);
+    const storeCurrentSchema = jest.fn();
+    const migrator = Object.assign(
+      Object.create(RowLevelSecurityMigrator.prototype),
+      {
+        generator,
+        ensureMigrationsDirExists: jest.fn(),
+        getSchemaDiff: jest.fn().mockResolvedValue(diff),
+        storeCurrentSchema,
+      },
+    ) as RowLevelSecurityMigrator;
+
+    await expect(
+      migrator.createMigration("/tmp", false, false, "Migration"),
+    ).resolves.toEqual({
+      fileName: "Migration.ts",
+      code: "migration-file",
+      diff,
+    });
+    expect(hasPendingPolicyChanges).toHaveBeenCalledWith(diff);
+    expect(generate).toHaveBeenCalledWith(diff, "/tmp", "Migration");
+    expect(storeCurrentSchema).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps MikroORM no-op behavior when schema and policies are unchanged", async () => {
+    const diff = { up: [], down: [] };
+    const generator = createGenerator([]);
+    jest.spyOn(generator, "hasPendingPolicyChanges").mockResolvedValue(false);
+    const generate = jest.spyOn(generator, "generate");
+    const storeCurrentSchema = jest.fn();
+    const migrator = Object.assign(
+      Object.create(RowLevelSecurityMigrator.prototype),
+      {
+        generator,
+        ensureMigrationsDirExists: jest.fn(),
+        getSchemaDiff: jest.fn().mockResolvedValue(diff),
+        storeCurrentSchema,
+      },
+    ) as RowLevelSecurityMigrator;
+
+    await expect(migrator.createMigration()).resolves.toEqual({
+      fileName: "",
+      code: "",
+      diff,
+    });
+    expect(generate).not.toHaveBeenCalled();
+    expect(storeCurrentSchema).not.toHaveBeenCalled();
+  });
+
+  it("reports migration needed when only row-level-security policies changed", async () => {
+    const diff = { up: [], down: [] };
+    const generator = createGenerator([]);
+    jest.spyOn(generator, "hasPendingPolicyChanges").mockResolvedValue(true);
+    const migrator = Object.assign(
+      Object.create(RowLevelSecurityMigrator.prototype),
+      {
+        generator,
+        ensureMigrationsDirExists: jest.fn(),
+        getSchemaDiff: jest.fn().mockResolvedValue(diff),
+      },
+    ) as RowLevelSecurityMigrator;
+
+    await expect(migrator.checkMigrationNeeded()).resolves.toBe(true);
   });
 });
 

--- a/packages/row-level-security/src/row-level-security-migration-generator.spec.ts
+++ b/packages/row-level-security/src/row-level-security-migration-generator.spec.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { TSMigrationGenerator } from "@mikro-orm/migrations";
 
 import { Policy } from "./decorators/policy.decorator";
@@ -867,6 +871,92 @@ describe("RowLevelSecurityMigrator", () => {
     expect(storeCurrentSchema).toHaveBeenCalledTimes(1);
   });
 
+  it("generates a policy diff after an applied context policy changes", async () => {
+    const migrationPath = mkdtempSync(join(tmpdir(), "rls-policy-diff-"));
+    const diff = { up: [], down: [] };
+    const execute = jest.fn((_sql: string) =>
+      Promise.resolve([
+        {
+          policy_name: "workspace_member_workspace_select_policy",
+          schema_name: "public",
+          table_name: "workspace_member",
+          permissive: true,
+          command: "r",
+          qual: `((select app.get_context('tenant_id', null::bigint)) = "workspace_id")`,
+          with_check: null,
+          roles: ["authenticated"],
+        },
+      ]),
+    );
+    const generator = createGenerator(
+      [
+        {
+          class: WorkspaceMemberWithWorkspaceContextPolicy,
+          tableName: "workspace_member",
+          properties: {
+            workspace: {
+              fieldNames: ["workspace_id"],
+              columnTypes: ["bigint"],
+            },
+          },
+        },
+      ],
+      {
+        getConnection: () => ({
+          execute,
+        }),
+      },
+      {
+        path: migrationPath,
+        pathTs: migrationPath,
+      },
+    );
+    const storeCurrentSchema = jest.fn();
+    const migrator = Object.assign(
+      Object.create(RowLevelSecurityMigrator.prototype),
+      {
+        generator,
+        ensureMigrationsDirExists: jest.fn(),
+        getSchemaDiff: jest.fn().mockResolvedValue(diff),
+        storeCurrentSchema,
+      },
+    ) as RowLevelSecurityMigrator;
+
+    try {
+      const result = await migrator.createMigration(
+        migrationPath,
+        false,
+        false,
+        "MigrationPolicyContextDiff",
+      );
+
+      expect(result.fileName).toBe("MigrationPolicyContextDiff.ts");
+      expect(result.diff).toBe(diff);
+      expect(result.code).toContain("extends RowLevelSecurityMigration");
+      expect(result.code).toContain(
+        "drop policy if exists workspace_member_workspace_select_policy",
+      );
+      expect(result.code).toContain(
+        "app.get_context('workspace_id', null::bigint)",
+      );
+      expect(result.code).toContain(
+        "app.get_context('tenant_id', null::bigint)",
+      );
+      expect(
+        result.code.indexOf(
+          "drop policy if exists workspace_member_workspace_select_policy",
+        ),
+      ).toBeLessThan(
+        result.code.indexOf(
+          "create policy workspace_member_workspace_select_policy",
+        ),
+      );
+      expect(storeCurrentSchema).toHaveBeenCalledTimes(1);
+    } finally {
+      rmSync(migrationPath, { force: true, recursive: true });
+    }
+  });
+
   it("keeps MikroORM no-op behavior when schema and policies are unchanged", async () => {
     const diff = { up: [], down: [] };
     const generator = createGenerator([]);
@@ -912,17 +1002,26 @@ describe("RowLevelSecurityMigrator", () => {
 function createGenerator(
   metadata: object[],
   driverOptions: Record<string, unknown> = {},
+  generatorOptions: Record<string, unknown> = {},
 ) {
   return new RowLevelSecurityMigrationGenerator(
     {
       config: {
+        get: (key: string) => (key === "baseDir" ? process.cwd() : undefined),
         getMetadata: () => ({
           getAll: () => metadata,
         }),
       },
       ...driverOptions,
     } as never,
-    {} as never,
-    { emit: "ts" } as never,
+    {
+      classToMigrationName: (_timestamp: string, name?: string) =>
+        name ?? "Migration",
+    } as never,
+    {
+      emit: "ts",
+      fileName: (_timestamp: string, name?: string) => name ?? "Migration",
+      ...generatorOptions,
+    } as never,
   );
 }

--- a/packages/row-level-security/src/row-level-security-migration-generator.ts
+++ b/packages/row-level-security/src/row-level-security-migration-generator.ts
@@ -33,6 +33,31 @@ export class RowLevelSecurityMigrationGenerator extends TSMigrationGenerator {
     path?: string,
     name?: string,
   ): Promise<[string, string]> {
+    return await this.withPolicyDefinitions(diff, () =>
+      super.generate(diff, path, name),
+    );
+  }
+
+  async hasPendingPolicyChanges(diff: MigrationDiff): Promise<boolean> {
+    return await this.withPolicyDefinitions(diff, () => {
+      if (!this.existingPolicyDefinitions) {
+        return false;
+      }
+
+      const currentPolicyDefinitions = this.currentPolicyDefinitions ?? [];
+      const { added, removed } = this.getPolicyDefinitionChanges(
+        diff,
+        currentPolicyDefinitions,
+      );
+
+      return added.length > 0 || removed.length > 0;
+    });
+  }
+
+  private async withPolicyDefinitions<T>(
+    diff: MigrationDiff,
+    callback: () => Promise<T> | T,
+  ): Promise<T> {
     const entityMetadata = this.getEntityMetadata();
     const currentPolicyDefinitions = this.getPolicyDefinitions(entityMetadata);
     const tableReferences = getPolicyDefinitionTableReferences(
@@ -52,7 +77,7 @@ export class RowLevelSecurityMigrationGenerator extends TSMigrationGenerator {
     this.currentPolicyDefinitions = currentPolicyDefinitions;
 
     try {
-      return await super.generate(diff, path, name);
+      return await callback();
     } finally {
       this.existingPolicyDefinitions = undefined;
       this.existingPolicyRoleDefinitions = undefined;

--- a/packages/row-level-security/src/row-level-security-migration-generator.ts
+++ b/packages/row-level-security/src/row-level-security-migration-generator.ts
@@ -38,6 +38,7 @@ export class RowLevelSecurityMigrationGenerator extends TSMigrationGenerator {
     );
   }
 
+  /** Returns whether the current metadata contains RLS policy changes not present in the database. */
   async hasPendingPolicyChanges(diff: MigrationDiff): Promise<boolean> {
     return await this.withPolicyDefinitions(diff, () => {
       if (!this.existingPolicyDefinitions) {

--- a/packages/row-level-security/src/row-level-security-migrator.ts
+++ b/packages/row-level-security/src/row-level-security-migrator.ts
@@ -1,0 +1,95 @@
+import type { MigrationDiff, MigrationResult, MikroORM } from "@mikro-orm/core";
+import { Migrator } from "@mikro-orm/migrations";
+
+import { RowLevelSecurityMigrationGenerator } from "./row-level-security-migration-generator";
+
+interface MigrationGeneratorLike {
+  generate(
+    diff: MigrationDiff,
+    path?: string,
+    name?: string,
+  ): Promise<[string, string]>;
+}
+
+interface MigratorInternals {
+  generator: MigrationGeneratorLike;
+  ensureMigrationsDirExists(): Promise<void>;
+  getSchemaDiff(blank: boolean, initial: boolean): Promise<MigrationDiff>;
+  storeCurrentSchema(): Promise<void>;
+}
+
+/** MikroORM migrator that also creates migrations for policy-only RLS changes. */
+export class RowLevelSecurityMigrator extends Migrator {
+  static override register(orm: MikroORM): void {
+    orm.config.registerExtension(
+      "@mikro-orm/migrator",
+      () => new RowLevelSecurityMigrator(orm.em as never),
+    );
+  }
+
+  override async createMigration(
+    path?: string,
+    blank = false,
+    initial = false,
+    name?: string,
+  ): Promise<MigrationResult> {
+    if (initial) {
+      return await super.createMigration(path, blank, initial, name);
+    }
+
+    const internals = this.getInternals();
+
+    await internals.ensureMigrationsDirExists();
+
+    const diff = await internals.getSchemaDiff(blank, initial);
+
+    if (diff.up.length === 0) {
+      const generator = this.getRowLevelSecurityGenerator();
+      const hasPolicyChanges = generator
+        ? await generator.hasPendingPolicyChanges(diff)
+        : false;
+
+      if (!hasPolicyChanges) {
+        return { fileName: "", code: "", diff };
+      }
+    }
+
+    const migration = await internals.generator.generate(diff, path, name);
+
+    await internals.storeCurrentSchema();
+
+    return {
+      fileName: migration[1],
+      code: migration[0],
+      diff,
+    };
+  }
+
+  override async checkMigrationNeeded(): Promise<boolean> {
+    const internals = this.getInternals();
+
+    await internals.ensureMigrationsDirExists();
+
+    const diff = await internals.getSchemaDiff(false, false);
+
+    if (diff.up.length > 0) {
+      return true;
+    }
+
+    const generator = this.getRowLevelSecurityGenerator();
+
+    return generator ? await generator.hasPendingPolicyChanges(diff) : false;
+  }
+
+  private getRowLevelSecurityGenerator() {
+    const generator = this.getInternals().generator;
+
+    return generator instanceof RowLevelSecurityMigrationGenerator
+      ? generator
+      : undefined;
+  }
+
+  private getInternals() {
+    return this as unknown as MigratorInternals;
+  }
+}

--- a/packages/row-level-security/src/row-level-security-migrator.ts
+++ b/packages/row-level-security/src/row-level-security-migrator.ts
@@ -45,10 +45,7 @@ export class RowLevelSecurityMigrator extends Migrator {
     const diff = await internals.getSchemaDiff(blank, initial);
 
     if (diff.up.length === 0) {
-      const generator = this.getRowLevelSecurityGenerator();
-      const hasPolicyChanges = generator
-        ? await generator.hasPendingPolicyChanges(diff)
-        : false;
+      const hasPolicyChanges = await this.hasPendingPolicyChanges(diff);
 
       if (!hasPolicyChanges) {
         return { fileName: "", code: "", diff };
@@ -78,8 +75,14 @@ export class RowLevelSecurityMigrator extends Migrator {
       return true;
     }
 
+    return await this.hasPendingPolicyChanges(diff);
+  }
+
+  private async hasPendingPolicyChanges(diff: MigrationDiff): Promise<boolean> {
     const generator = this.getRowLevelSecurityGenerator();
 
+    // TODO: Support MikroORM snapshot mode by comparing generated policy state
+    // instead of only live database policies.
     return generator ? await generator.hasPendingPolicyChanges(diff) : false;
   }
 

--- a/packages/row-level-security/src/row-level-security-migrator.ts
+++ b/packages/row-level-security/src/row-level-security-migrator.ts
@@ -20,6 +20,7 @@ interface MigratorInternals {
 
 /** MikroORM migrator that also creates migrations for policy-only RLS changes. */
 export class RowLevelSecurityMigrator extends Migrator {
+  /** Registers the RLS-aware migrator extension with a MikroORM instance. */
   static override register(orm: MikroORM): void {
     orm.config.registerExtension(
       "@mikro-orm/migrator",
@@ -65,6 +66,7 @@ export class RowLevelSecurityMigrator extends Migrator {
     };
   }
 
+  /** Checks whether schema or RLS policy changes require a new migration. */
   override async checkMigrationNeeded(): Promise<boolean> {
     const internals = this.getInternals();
 

--- a/packages/row-level-security/test/row-level-security-e2e.spec.ts
+++ b/packages/row-level-security/test/row-level-security-e2e.spec.ts
@@ -5,7 +5,11 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { MikroORM, ReflectMetadataProvider } from "@mikro-orm/core";
+import {
+  type EntityClass,
+  MikroORM,
+  ReflectMetadataProvider,
+} from "@mikro-orm/core";
 import {
   Entity,
   Knex,
@@ -503,8 +507,8 @@ describe("RowLevelSecurity - database integration", () => {
     });
   }
 
-  async function createPolicyMigrationOrm(
-    entity: object,
+  async function createPolicyMigrationOrm<T extends object>(
+    entity: EntityClass<T>,
     migrationPath: string,
   ) {
     const databaseConfig = await loadConfigFromEnv();

--- a/packages/row-level-security/test/row-level-security-e2e.spec.ts
+++ b/packages/row-level-security/test/row-level-security-e2e.spec.ts
@@ -1,7 +1,11 @@
 import "dotenv/config";
 import "reflect-metadata";
 
-import { MikroORM } from "@mikro-orm/core";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { MikroORM, ReflectMetadataProvider } from "@mikro-orm/core";
 import {
   Entity,
   Knex,
@@ -11,7 +15,7 @@ import {
   Ref,
   t,
 } from "@mikro-orm/postgresql";
-import { MikroOrmModule } from "@nest-boot/mikro-orm";
+import { loadConfigFromEnv, MikroOrmModule } from "@nest-boot/mikro-orm";
 import { RequestContext } from "@nest-boot/request-context";
 import { Test, TestingModule } from "@nestjs/testing";
 
@@ -19,11 +23,14 @@ import {
   createPolicyBootstrapSqlStatements,
   createPolicyRoleUpSqlStatements,
   createPolicyUpSqlStatements,
+  Policy,
   PolicyCommand,
   quoteIdentifier,
   quoteQualifiedIdentifier,
   RowLevelSecurity,
   RowLevelSecurityDriver,
+  RowLevelSecurityMigrationGenerator,
+  RowLevelSecurityMigrator,
   RowLevelSecurityMode,
 } from "../src";
 
@@ -32,6 +39,13 @@ const DOCUMENT_SCHEMA_NAME = `rls_e2e_${String(process.pid)}_${String(
 )}`;
 const DOCUMENT_TABLE_NAME = "documents";
 const MEMBER_TABLE_NAME = "members";
+const POLICY_MIGRATION_SUFFIX = `${String(process.pid)}_${String(
+  Date.now(),
+).slice(-8)}`;
+const POLICY_MIGRATION_SCHEMA_NAME = `rls_migration_e2e_${POLICY_MIGRATION_SUFFIX}`;
+const POLICY_MIGRATION_TABLE_NAME = "policy_documents";
+const POLICY_MIGRATION_POLICY_NAME = `${POLICY_MIGRATION_TABLE_NAME}_workspace_select_policy`;
+const POLICY_MIGRATION_STORAGE_TABLE = `rls_migrations_${POLICY_MIGRATION_SUFFIX}`;
 
 @Entity({ schema: DOCUMENT_SCHEMA_NAME, tableName: MEMBER_TABLE_NAME })
 class RowLevelSecurityMemberEntity {
@@ -61,6 +75,44 @@ class RowLevelSecurityDocumentEntity {
     ref: true,
   })
   member!: Ref<RowLevelSecurityMemberEntity>;
+}
+
+@Policy({
+  name: POLICY_MIGRATION_POLICY_NAME,
+  command: PolicyCommand.SELECT,
+  property: "workspaceId",
+  context: "tenant_id",
+  roles: ["authenticated"],
+})
+@Entity({
+  schema: POLICY_MIGRATION_SCHEMA_NAME,
+  tableName: POLICY_MIGRATION_TABLE_NAME,
+})
+class RowLevelSecurityMigrationTenantContextEntity {
+  @PrimaryKey({ type: t.integer })
+  id!: number;
+
+  @Property({ fieldName: "workspace_id", type: t.integer })
+  workspaceId!: number;
+}
+
+@Policy({
+  name: POLICY_MIGRATION_POLICY_NAME,
+  command: PolicyCommand.SELECT,
+  property: "workspaceId",
+  context: "workspace_id",
+  roles: ["authenticated"],
+})
+@Entity({
+  schema: POLICY_MIGRATION_SCHEMA_NAME,
+  tableName: POLICY_MIGRATION_TABLE_NAME,
+})
+class RowLevelSecurityMigrationWorkspaceContextEntity {
+  @PrimaryKey({ type: t.integer })
+  id!: number;
+
+  @Property({ fieldName: "workspace_id", type: t.integer })
+  workspaceId!: number;
 }
 
 describe("RowLevelSecurity - database integration", () => {
@@ -293,6 +345,71 @@ describe("RowLevelSecurity - database integration", () => {
     expect(member.name).toBe("tenant-1-member");
   });
 
+  it("generates a policy diff after applying a migration and changing only context", async () => {
+    const migrationPath = mkdtempSync(join(tmpdir(), "rls-policy-migrations-"));
+    let tenantOrm: MikroORM | undefined;
+    let workspaceOrm: MikroORM | undefined;
+
+    try {
+      tenantOrm = await createPolicyMigrationOrm(
+        RowLevelSecurityMigrationTenantContextEntity,
+        migrationPath,
+      );
+      await dropPolicyMigrationSchema(tenantOrm);
+
+      const initialMigration = await (
+        tenantOrm.migrator as RowLevelSecurityMigrator
+      ).createInitialMigration(migrationPath, "InitialPolicyContext");
+
+      expect(initialMigration.code).toContain(
+        "app.get_context('tenant_id', null::integer)",
+      );
+
+      await runGeneratedMigrationUpStatements(tenantOrm, initialMigration.code);
+      await tenantOrm.close(true);
+      tenantOrm = undefined;
+
+      workspaceOrm = await createPolicyMigrationOrm(
+        RowLevelSecurityMigrationWorkspaceContextEntity,
+        migrationPath,
+      );
+
+      const policyDiffMigration = await (
+        workspaceOrm.migrator as RowLevelSecurityMigrator
+      ).createMigration(migrationPath, false, false, "UpdatePolicyContext");
+
+      expect(policyDiffMigration.fileName).toBe("UpdatePolicyContext.ts");
+      expect(policyDiffMigration.diff.up).toEqual([]);
+      expect(policyDiffMigration.code).toContain(
+        `drop policy if exists ${POLICY_MIGRATION_POLICY_NAME}`,
+      );
+      expect(policyDiffMigration.code).toContain(
+        "app.get_context('workspace_id', null::integer)",
+      );
+      expect(policyDiffMigration.code).toContain("app.get_context('tenant_id'");
+
+      await runGeneratedMigrationUpStatements(
+        workspaceOrm,
+        policyDiffMigration.code,
+      );
+
+      const policy = await getGeneratedPolicyExpression(workspaceOrm);
+
+      expect(policy.qual).toContain("workspace_id");
+      expect(policy.qual).not.toContain("tenant_id");
+    } finally {
+      const cleanupOrm = workspaceOrm ?? tenantOrm;
+
+      if (cleanupOrm) {
+        await dropPolicyMigrationSchema(cleanupOrm);
+      }
+
+      await workspaceOrm?.close(true);
+      await tenantOrm?.close(true);
+      rmSync(migrationPath, { force: true, recursive: true });
+    }
+  }, 30000);
+
   async function resetSchema() {
     await dropSchema();
     await orm.schema.createSchema({ schema: DOCUMENT_SCHEMA_NAME });
@@ -384,5 +501,89 @@ describe("RowLevelSecurity - database integration", () => {
 
       return await callback(trx);
     });
+  }
+
+  async function createPolicyMigrationOrm(
+    entity: object,
+    migrationPath: string,
+  ) {
+    const databaseConfig = await loadConfigFromEnv();
+
+    return await MikroORM.init({
+      ...databaseConfig,
+      allowGlobalContext: true,
+      driver: RowLevelSecurityDriver,
+      entities: [entity],
+      extensions: [RowLevelSecurityMigrator],
+      metadataCache: {
+        enabled: false,
+      },
+      metadataProvider: ReflectMetadataProvider,
+      migrations: {
+        emit: "ts",
+        generator: RowLevelSecurityMigrationGenerator,
+        path: migrationPath,
+        pathTs: migrationPath,
+        snapshot: false,
+        tableName: POLICY_MIGRATION_STORAGE_TABLE,
+      },
+    });
+  }
+
+  async function dropPolicyMigrationSchema(targetOrm: MikroORM) {
+    await targetOrm.schema.dropSchema({
+      dropDb: false,
+      dropMigrationsTable: false,
+      schema: POLICY_MIGRATION_SCHEMA_NAME,
+    });
+    await targetOrm.em
+      .getConnection()
+      .execute(
+        `drop table if exists ${quoteIdentifier(
+          POLICY_MIGRATION_STORAGE_TABLE,
+        )} cascade`,
+      );
+  }
+
+  async function runGeneratedMigrationUpStatements(
+    targetOrm: MikroORM,
+    code: string,
+  ) {
+    for (const statement of getGeneratedMigrationUpStatements(code)) {
+      await targetOrm.em.getConnection().execute(statement);
+    }
+  }
+
+  function getGeneratedMigrationUpStatements(code: string) {
+    const upStart = code.indexOf("async up()");
+    const downStart = code.indexOf("async down()", upStart);
+    const upCode = code.slice(
+      upStart,
+      downStart === -1 ? undefined : downStart,
+    );
+
+    return [...upCode.matchAll(/this\.addSql\(`((?:\\.|[^`])*)`\);/g)].map(
+      ([, sql]) => unescapeGeneratedMigrationSql(sql),
+    );
+  }
+
+  function unescapeGeneratedMigrationSql(sql: string) {
+    return sql.replace(/\\([`$\\])/g, "$1");
+  }
+
+  async function getGeneratedPolicyExpression(targetOrm: MikroORM) {
+    return await targetOrm.em.getConnection().execute<{ qual: string }>(
+      /* SQL */ `
+        SELECT pg_get_expr(p.polqual, p.polrelid) AS qual
+        FROM pg_policy p
+        INNER JOIN pg_class c ON c.oid = p.polrelid
+        INNER JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = '${POLICY_MIGRATION_SCHEMA_NAME}'
+          AND c.relname = '${POLICY_MIGRATION_TABLE_NAME}'
+          AND p.polname = '${POLICY_MIGRATION_POLICY_NAME}'
+      `,
+      [],
+      "get",
+    );
   }
 });

--- a/packages/row-level-security/test/row-level-security-e2e.spec.ts
+++ b/packages/row-level-security/test/row-level-security-e2e.spec.ts
@@ -351,6 +351,8 @@ describe("RowLevelSecurity - database integration", () => {
     let workspaceOrm: MikroORM | undefined;
 
     try {
+      await dropGeneratedTestArtifacts(orm);
+
       tenantOrm = await createPolicyMigrationOrm(
         RowLevelSecurityMigrationTenantContextEntity,
         migrationPath,
@@ -361,9 +363,7 @@ describe("RowLevelSecurity - database integration", () => {
         tenantOrm.migrator as RowLevelSecurityMigrator
       ).createInitialMigration(migrationPath, "InitialPolicyContext");
 
-      expect(initialMigration.code).toContain(
-        "app.get_context('tenant_id', null::integer)",
-      );
+      expect(initialMigration.code).toContain("app.get_context('tenant_id'");
 
       await runGeneratedMigrationUpStatements(tenantOrm, initialMigration.code);
       await tenantOrm.close(true);
@@ -378,13 +378,13 @@ describe("RowLevelSecurity - database integration", () => {
         workspaceOrm.migrator as RowLevelSecurityMigrator
       ).createMigration(migrationPath, false, false, "UpdatePolicyContext");
 
-      expect(policyDiffMigration.fileName).toBe("UpdatePolicyContext.ts");
+      expect(policyDiffMigration.fileName).toMatch(/UpdatePolicyContext\.ts$/);
       expect(policyDiffMigration.diff.up).toEqual([]);
       expect(policyDiffMigration.code).toContain(
         `drop policy if exists ${POLICY_MIGRATION_POLICY_NAME}`,
       );
       expect(policyDiffMigration.code).toContain(
-        "app.get_context('workspace_id', null::integer)",
+        "app.get_context('workspace_id'",
       );
       expect(policyDiffMigration.code).toContain("app.get_context('tenant_id'");
 
@@ -514,12 +514,14 @@ describe("RowLevelSecurity - database integration", () => {
       allowGlobalContext: true,
       driver: RowLevelSecurityDriver,
       entities: [entity],
+      entitiesTs: [entity],
       extensions: [RowLevelSecurityMigrator],
       metadataCache: {
         enabled: false,
       },
       metadataProvider: ReflectMetadataProvider,
       migrations: {
+        dropTables: false,
         emit: "ts",
         generator: RowLevelSecurityMigrationGenerator,
         path: migrationPath,
@@ -527,6 +529,7 @@ describe("RowLevelSecurity - database integration", () => {
         snapshot: false,
         tableName: POLICY_MIGRATION_STORAGE_TABLE,
       },
+      schema: POLICY_MIGRATION_SCHEMA_NAME,
     });
   }
 
@@ -543,6 +546,38 @@ describe("RowLevelSecurity - database integration", () => {
           POLICY_MIGRATION_STORAGE_TABLE,
         )} cascade`,
       );
+  }
+
+  async function dropGeneratedTestArtifacts(targetOrm: MikroORM) {
+    const schemas = await targetOrm.em.getConnection().execute<
+      { nspname: string }[]
+    >(/* SQL */ `
+        SELECT nspname
+        FROM pg_namespace
+        WHERE nspname LIKE 'rls_e2e_%'
+          OR nspname LIKE 'rls_migration_e2e_%'
+      `);
+
+    for (const { nspname } of schemas) {
+      await targetOrm.em
+        .getConnection()
+        .execute(`drop schema if exists ${quoteIdentifier(nspname)} cascade`);
+    }
+
+    const tables = await targetOrm.em.getConnection().execute<
+      { tablename: string }[]
+    >(/* SQL */ `
+        SELECT tablename
+        FROM pg_tables
+        WHERE schemaname = 'public'
+          AND tablename LIKE 'rls_migrations_%'
+      `);
+
+    for (const { tablename } of tables) {
+      await targetOrm.em
+        .getConnection()
+        .execute(`drop table if exists ${quoteIdentifier(tablename)} cascade`);
+    }
   }
 
   async function runGeneratedMigrationUpStatements(


### PR DESCRIPTION
## Summary

Fixes #239.

- Add `RowLevelSecurityMigrator`, an RLS-aware MikroORM migrator extension that checks policy diffs when the schema diff is otherwise empty.
- Add `RowLevelSecurityMigrationGenerator.hasPendingPolicyChanges()` so policy-only changes, including `@Policy({ context })` updates, can be detected before MikroORM returns "no changes".
- Export and document the new migrator configuration, including English and zh-Hans docs, plus a patch changeset.
- Add focused unit and database e2e coverage for the flow where an initial policy migration has been applied, the policy `context` changes, and the next migration generation emits a policy diff.
- Fix the docs/Vercel build by typing the e2e helper entity as a MikroORM entity class and documenting the new public migration APIs.
- Add a no-emit TypeDoc check to PR/release GitHub Actions and the local pre-commit check.
- Document that policy-only diff detection currently requires `migrations.snapshot: false`, and add a code TODO for future snapshot-backed policy tracking.

## Root Cause

MikroORM's default `Migrator.createMigration()` returns before invoking the configured migration generator when `diff.up.length === 0`. That meant the existing RLS generator never had a chance to compare database policy SQL against metadata-derived policy SQL for policy-only changes.

## Validation

- `pnpm --filter @nest-boot/row-level-security lint`
- `pnpm --filter @nest-boot/row-level-security exec jest src --runInBand`
- `pnpm --filter @nest-boot/row-level-security build`
- `DB_TYPE=postgresql DB_HOST=127.0.0.1 DB_PORT=5432 DB_NAME=postgres DB_USER=postgres DB_PASSWORD=secret pnpm --filter @nest-boot/row-level-security exec jest --runInBand`
- `pnpm --filter @nest-boot/docs build`
- `pnpm docs:check`
- pre-commit `pnpm commit:check` passed while creating commits `2181889` and `ff9c16c`
- GitHub Actions run `26456923392`: Build, Lint, Test, and TypeDoc passed
- Vercel deployment `9KRPxx4eGw7j4FSgSiWc9Vu4YUCt` passed
