### PR TITLE
feat(auth): expose AuthGuard.isPublic

### DIFF
--- a/.changeset/warm-auth-guards.md
+++ b/.changeset/warm-auth-guards.md
@@ -1,0 +1,5 @@
+---
+"@nest-boot/auth": minor
+---
+
+Expose `AuthGuard.isPublic()` for subclasses and guard mixins.

--- a/packages/auth/src/auth.guard.spec.ts
+++ b/packages/auth/src/auth.guard.spec.ts
@@ -1,6 +1,8 @@
 import { type CanActivate, type ExecutionContext } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
 import { of } from "rxjs";
 
+import { IS_PUBLIC_KEY } from "./auth.constants";
 import { AuthGuard } from "./auth.guard";
 
 class PromiseAuthGuard extends AuthGuard {
@@ -19,9 +21,36 @@ class ObservableAuthGuard extends AuthGuard {
   }
 }
 
+class PublicAwareAuthGuard extends AuthGuard {
+  isContextPublic(context: ExecutionContext): boolean {
+    return this.isPublic(context);
+  }
+}
+
 describe("AuthGuard", () => {
   it("allows subclasses to return the full CanActivate result type", () => {
     expect(PromiseAuthGuard).toBeDefined();
     expect(ObservableAuthGuard).toBeDefined();
+  });
+
+  it("allows subclasses to reuse the public route metadata lookup", () => {
+    const handler = () => undefined;
+    class TestController {}
+
+    const context = {
+      getClass: jest.fn(() => TestController),
+      getHandler: jest.fn(() => handler),
+    } as unknown as ExecutionContext;
+
+    const getAllAndOverride = jest.fn(() => true);
+    const guard = new PublicAwareAuthGuard({
+      getAllAndOverride,
+    } as unknown as Reflector);
+
+    expect(guard.isContextPublic(context)).toBe(true);
+    expect(getAllAndOverride).toHaveBeenCalledWith(IS_PUBLIC_KEY, [
+      handler,
+      TestController,
+    ]);
   });
 });

--- a/packages/auth/src/auth.guard.ts
+++ b/packages/auth/src/auth.guard.ts
@@ -24,6 +24,18 @@ export class AuthGuard implements CanActivate {
   constructor(protected readonly reflector: Reflector) {}
 
   /**
+   * Determines whether the current route is marked as public.
+   * @param context - The execution context of the current request
+   * @returns True when authentication should be skipped
+   */
+  protected isPublic(context: ExecutionContext): boolean {
+    return !!this.reflector.getAllAndOverride(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+  }
+
+  /**
    * Determines whether the current request is allowed to proceed.
    * @param context - The execution context of the current request
    * @returns A NestJS guard activation result
@@ -31,12 +43,7 @@ export class AuthGuard implements CanActivate {
   canActivate(
     context: ExecutionContext,
   ): ReturnType<CanActivate["canActivate"]> {
-    if (
-      this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
-        context.getHandler(),
-        context.getClass(),
-      ])
-    ) {
+    if (this.isPublic(context)) {
       return true;
     }
 


### PR DESCRIPTION
## Summary

- Adds a protected `AuthGuard.isPublic(context)` helper that centralizes the `@Public()` metadata lookup.
- Updates `AuthGuard.canActivate()` to call the helper before checking the request session.
- Adds a regression test proving subclasses can reuse the public-route lookup and adds a minor changeset for `@nest-boot/auth`.

## Root Cause

`AuthGuard.canActivate()` previously inlined the `IS_PUBLIC_KEY` reflector lookup, so subclasses and guard mixins had to duplicate that metadata logic when extending authentication behavior.

Closes #242

## Validation

- `pnpm --filter @nest-boot/auth test -- auth.guard.spec.ts --runInBand` (red before implementation, then green)
- `pnpm --filter @nest-boot/auth exec jest --runInBand`
- `pnpm --filter @nest-boot/auth build`
- `pnpm exec prettier --write packages/auth/src/auth.guard.ts packages/auth/src/auth.guard.spec.ts .changeset/warm-auth-guards.md`
- `pnpm --filter @nest-boot/auth exec eslint src/auth.guard.ts src/auth.guard.spec.ts`
- `pnpm typedoc:check`
- `pnpm changeset status --since=origin/master`
- commit hook: `pnpm docs:check` (`pnpm build:packages && pnpm typedoc:check`)

Note: full auth package ESLint still reports pre-existing issues in `src/adapters/mikro-orm-adapter.*`; touched-file ESLint passes for this PR.