### PR TITLE
feat: add middleware ordering hints

### DIFF
--- a/.changeset/fresh-middleware-ordering.md
+++ b/.changeset/fresh-middleware-ordering.md
@@ -1,0 +1,5 @@
+---
+"@nest-boot/middleware": minor
+---
+
+Add soft before/after middleware ordering APIs while keeping dependencies as a hard prerequisite.

--- a/apps/docs/content/docs/tutorial/middleware.mdx
+++ b/apps/docs/content/docs/tutorial/middleware.mdx
@@ -33,12 +33,15 @@ import { Injectable, OnModuleInit } from "@nestjs/common";
 
 @Injectable()
 export class MyModule implements OnModuleInit {
-  constructor(private readonly middlewareManager: MiddlewareManager) {}
+  constructor(
+    private readonly middlewareManager: MiddlewareManager,
+    private readonly loggerMiddleware: LoggerMiddleware,
+  ) {}
 
   onModuleInit() {
     this.middlewareManager
-      .apply(MyCustomMiddleware)
-      .dependencies(AuthMiddleware) // Run after auth
+      .apply(this.loggerMiddleware)
+      .before(AuthMiddleware) // Log requests before auth runs, when auth is registered
       .forRoutes("*");
   }
 }
@@ -46,9 +49,37 @@ export class MyModule implements OnModuleInit {
 
 ### Key Features
 
-- **Dependency Resolution** — Declare dependencies between middleware to ensure correct execution order
+- **Soft Ordering** — Use `before(...)` and `after(...)` to express preferred execution order when the target middleware is registered
+- **Hard Dependencies** — Use `dependencies(...)` when another middleware must be registered and must run first
 - **Global Excludes** — Exclude routes from all middleware (e.g., auth API routes)
 - **Route Scoping** — Apply middleware to specific routes or patterns
+
+## Ordering Middleware
+
+Use `before(...)` and `after(...)` when the target middleware is optional. If the target middleware is registered, the manager applies the requested order. If it is not registered, the ordering hint is ignored.
+
+```typescript
+this.middlewareManager
+  .apply(this.loggerMiddleware)
+  .before(AuthMiddleware)
+  .forRoutes("*");
+
+this.middlewareManager
+  .apply(this.auditMiddleware)
+  .after(AuthMiddleware)
+  .forRoutes("*");
+```
+
+Use `dependencies(...)` when the current middleware cannot run correctly unless another middleware is registered and has already run. Missing dependencies throw during middleware configuration.
+
+```typescript
+this.middlewareManager
+  .apply(this.authMiddleware)
+  .dependencies(RequestContextMiddleware)
+  .forRoutes("*");
+```
+
+In this setup, the logger runs early when auth exists, auth requires request context, and audit logging runs after auth only in applications that register auth.
 
 ## API Reference
 

--- a/apps/docs/content/docs/tutorial/middleware.zh-Hans.mdx
+++ b/apps/docs/content/docs/tutorial/middleware.zh-Hans.mdx
@@ -33,12 +33,15 @@ import { Injectable, OnModuleInit } from "@nestjs/common";
 
 @Injectable()
 export class MyModule implements OnModuleInit {
-  constructor(private readonly middlewareManager: MiddlewareManager) {}
+  constructor(
+    private readonly middlewareManager: MiddlewareManager,
+    private readonly loggerMiddleware: LoggerMiddleware,
+  ) {}
 
   onModuleInit() {
     this.middlewareManager
-      .apply(MyCustomMiddleware)
-      .dependencies(AuthMiddleware) // 在认证之后运行
+      .apply(this.loggerMiddleware)
+      .before(AuthMiddleware) // 如果已注册 AuthMiddleware，则在认证前记录请求日志
       .forRoutes("*");
   }
 }
@@ -46,9 +49,37 @@ export class MyModule implements OnModuleInit {
 
 ### 核心特性
 
-- **依赖解析** — 声明中间件之间的依赖关系，确保正确的执行顺序
+- **软排序** — 使用 `before(...)` 和 `after(...)` 表达“如果目标中间件已注册，则按指定顺序执行”
+- **硬依赖** — 使用 `dependencies(...)` 表达“目标中间件必须注册，并且必须先执行”
 - **全局排除** — 将路由从所有中间件中排除（例如认证 API 路由）
 - **路由作用域** — 将中间件应用到特定路由或模式
+
+## 中间件排序
+
+当目标中间件是可选的，使用 `before(...)` 和 `after(...)`。如果目标中间件已注册，`MiddlewareManager` 会按要求排序；如果目标中间件未注册，这个排序提示会被忽略。
+
+```typescript
+this.middlewareManager
+  .apply(this.loggerMiddleware)
+  .before(AuthMiddleware)
+  .forRoutes("*");
+
+this.middlewareManager
+  .apply(this.auditMiddleware)
+  .after(AuthMiddleware)
+  .forRoutes("*");
+```
+
+当当前中间件必须依赖另一个中间件先注册并先执行，使用 `dependencies(...)`。依赖中间件缺失时，会在中间件配置阶段抛出异常。
+
+```typescript
+this.middlewareManager
+  .apply(this.authMiddleware)
+  .dependencies(RequestContextMiddleware)
+  .forRoutes("*");
+```
+
+在这个配置里，如果应用注册了认证中间件，日志中间件会尽早记录请求；认证中间件硬依赖请求上下文；审计日志只会在注册了认证中间件的应用中排在认证之后。
 
 ## API 参考
 

--- a/packages/middleware/src/interfaces/middleware-config.interface.ts
+++ b/packages/middleware/src/interfaces/middleware-config.interface.ts
@@ -13,8 +13,12 @@ export interface MiddlewareConfig {
   routes: (string | Type | RouteInfo)[];
   /** Routes to exclude from the middleware */
   excludeRoutes: (string | RouteInfo)[];
-  /** Middlewares that must be applied before this one */
+  /** Middlewares that must be registered and applied before this one */
   dependencyMiddlewares: Type<NestMiddleware>[];
+  /** Middlewares that should be applied before this one when registered */
+  afterMiddlewares: Type<NestMiddleware>[];
+  /** Middlewares that should be applied after this one when registered */
+  beforeMiddlewares: Type<NestMiddleware>[];
   /** Whether to disable global exclude routes for this middleware */
   disabledGlobalExcludeRoutes: boolean;
 }

--- a/packages/middleware/src/middleware.configurator.ts
+++ b/packages/middleware/src/middleware.configurator.ts
@@ -21,6 +21,12 @@ export class MiddlewareConfigurator {
   /** Middleware types that must run before this middleware. @internal */
   private readonly dependencyMiddlewares: Type<NestMiddleware>[] = [];
 
+  /** Middleware types that should run before this middleware when registered. @internal */
+  private readonly afterMiddlewares: Type<NestMiddleware>[] = [];
+
+  /** Middleware types that should run after this middleware when registered. @internal */
+  private readonly beforeMiddlewares: Type<NestMiddleware>[] = [];
+
   /**
    * Creates a new MiddlewareConfigurator instance.
    * @param manager - The middleware manager that owns this configurator
@@ -51,7 +57,41 @@ export class MiddlewareConfigurator {
   }
 
   /**
-   * Declares middleware dependencies for ordering.
+   * Declares middlewares that should run after this middleware when registered.
+   *
+   * @remarks
+   * This is a soft ordering hint. Unregistered middleware types are ignored.
+   *
+   * @param beforeMiddlewares - Middleware types that should run after this middleware
+   * @returns This configurator for chaining
+   */
+  public before(...beforeMiddlewares: Type<NestMiddleware>[]): this {
+    this.beforeMiddlewares.push(...beforeMiddlewares);
+    return this;
+  }
+
+  /**
+   * Declares middlewares that should run before this middleware when registered.
+   *
+   * @remarks
+   * This is a soft ordering hint. Unregistered middleware types are ignored.
+   *
+   * @param afterMiddlewares - Middleware types that should run before this middleware
+   * @returns This configurator for chaining
+   */
+  public after(...afterMiddlewares: Type<NestMiddleware>[]): this {
+    this.afterMiddlewares.push(...afterMiddlewares);
+    return this;
+  }
+
+  /**
+   * Declares middleware dependencies for ordering. Dependencies must be registered
+   * and must run before this middleware.
+   *
+   * @remarks
+   * This is a hard prerequisite. An unregistered dependency throws during
+   * middleware configuration.
+   *
    * @param dependencyMiddlewares - Middleware types that must run before this middleware
    * @returns This configurator for chaining
    */
@@ -84,6 +124,8 @@ export class MiddlewareConfigurator {
         routes,
         excludeRoutes: this.excludeRoutes,
         dependencyMiddlewares: this.dependencyMiddlewares,
+        afterMiddlewares: this.afterMiddlewares,
+        beforeMiddlewares: this.beforeMiddlewares,
         disabledGlobalExcludeRoutes: this.disabledGlobalExcludeRoutes,
       });
     });

--- a/packages/middleware/src/middleware.manager.spec.ts
+++ b/packages/middleware/src/middleware.manager.spec.ts
@@ -1,0 +1,215 @@
+import { NestMiddleware } from "@nestjs/common";
+import { MiddlewareConsumer } from "@nestjs/common/interfaces";
+
+import * as MiddlewareExports from ".";
+import { MiddlewareManager } from "./middleware.manager";
+import { MiddlewareModule } from "./middleware.module";
+import { MiddlewareFunction } from "./types";
+
+abstract class RecordingMiddleware implements NestMiddleware {
+  constructor(
+    private readonly name: string,
+    private readonly calls: string[],
+  ) {}
+
+  use(_req: unknown, _res: unknown, next: () => void) {
+    this.calls.push(this.name);
+    next();
+  }
+}
+
+class FirstMiddleware extends RecordingMiddleware {}
+class SecondMiddleware extends RecordingMiddleware {}
+class MissingMiddleware extends RecordingMiddleware {}
+
+const createMiddlewareConsumer = () => {
+  const middlewares: MiddlewareFunction[] = [];
+  const proxy = {
+    exclude: jest.fn().mockReturnThis(),
+    forRoutes: jest.fn().mockReturnThis(),
+  };
+  const consumer = {
+    apply: jest.fn((middleware: MiddlewareFunction) => {
+      middlewares.push(middleware);
+      return proxy;
+    }),
+  } as unknown as MiddlewareConsumer;
+
+  return { consumer, middlewares, proxy };
+};
+
+const collectMiddlewares = (manager: MiddlewareManager) => {
+  const { consumer, middlewares } = createMiddlewareConsumer();
+
+  manager.configure(consumer);
+
+  return middlewares;
+};
+
+const runMiddlewares = (middlewares: MiddlewareFunction[]) => {
+  for (const middleware of middlewares) {
+    middleware({}, {}, jest.fn());
+  }
+};
+
+describe("MiddlewareManager", () => {
+  it("exports middleware APIs from the package entrypoint", () => {
+    expect(MiddlewareExports.MiddlewareManager).toBe(MiddlewareManager);
+    expect(MiddlewareExports.MiddlewareModule).toBe(MiddlewareModule);
+  });
+
+  it("applies middleware after target middleware", () => {
+    const calls: string[] = [];
+    const first = new FirstMiddleware("first", calls);
+    const second = new SecondMiddleware("second", calls);
+    const manager = new MiddlewareManager();
+
+    manager.apply(second).after(FirstMiddleware).forRoutes("*");
+    manager.apply(first).forRoutes("*");
+
+    runMiddlewares(collectMiddlewares(manager));
+
+    expect(calls).toEqual(["first", "second"]);
+  });
+
+  it("applies hard dependency middleware before current middleware", () => {
+    const calls: string[] = [];
+    const first = new FirstMiddleware("first", calls);
+    const second = new SecondMiddleware("second", calls);
+    const manager = new MiddlewareManager();
+
+    manager.apply(second).dependencies(FirstMiddleware).forRoutes("*");
+    manager.apply(first).forRoutes("*");
+
+    runMiddlewares(collectMiddlewares(manager));
+
+    expect(calls).toEqual(["first", "second"]);
+  });
+
+  it("applies middleware before target middleware", () => {
+    const calls: string[] = [];
+    const first = new FirstMiddleware("first", calls);
+    const second = new SecondMiddleware("second", calls);
+    const manager = new MiddlewareManager();
+
+    manager.apply(second).forRoutes("*");
+    manager.apply(first).before(SecondMiddleware).forRoutes("*");
+
+    runMiddlewares(collectMiddlewares(manager));
+
+    expect(calls).toEqual(["first", "second"]);
+  });
+
+  it("ignores after target middleware when it is not registered", () => {
+    const calls: string[] = [];
+    const first = new FirstMiddleware("first", calls);
+    const manager = new MiddlewareManager();
+
+    manager.apply(first).after(MissingMiddleware).forRoutes("*");
+
+    runMiddlewares(collectMiddlewares(manager));
+
+    expect(calls).toEqual(["first"]);
+  });
+
+  it("ignores before target middleware when it is not registered", () => {
+    const calls: string[] = [];
+    const first = new FirstMiddleware("first", calls);
+    const manager = new MiddlewareManager();
+
+    manager.apply(first).before(MissingMiddleware).forRoutes("*");
+
+    runMiddlewares(collectMiddlewares(manager));
+
+    expect(calls).toEqual(["first"]);
+  });
+
+  it("throws when dependencies reference an unregistered middleware", () => {
+    const calls: string[] = [];
+    const first = new FirstMiddleware("first", calls);
+    const manager = new MiddlewareManager();
+
+    manager.apply(first).dependencies(MissingMiddleware).forRoutes("*");
+
+    expect(() => collectMiddlewares(manager)).toThrow(
+      "Dependency middleware MissingMiddleware is not registered",
+    );
+  });
+
+  it("throws when middleware ordering is circular", () => {
+    const calls: string[] = [];
+    const first = new FirstMiddleware("first", calls);
+    const second = new SecondMiddleware("second", calls);
+    const manager = new MiddlewareManager();
+
+    manager.apply(first).before(SecondMiddleware).forRoutes("*");
+    manager.apply(second).before(FirstMiddleware).forRoutes("*");
+
+    expect(() => collectMiddlewares(manager)).toThrow(
+      "Circular dependency detected in middleware",
+    );
+  });
+
+  it("applies function middleware with route exclusions", () => {
+    const calls: string[] = [];
+    const manager = new MiddlewareManager();
+    const { consumer, middlewares, proxy } = createMiddlewareConsumer();
+
+    manager
+      .globalExclude("/global")
+      .apply((_req, _res, next) => {
+        calls.push("function");
+        next();
+      })
+      .exclude("/local")
+      .forRoutes("/route");
+
+    manager.configure(consumer);
+    runMiddlewares(middlewares);
+
+    expect(proxy.exclude).toHaveBeenCalledWith("/global", "/local");
+    expect(proxy.forRoutes).toHaveBeenCalledWith("/route");
+    expect(calls).toEqual(["function"]);
+  });
+
+  it("can disable global exclude routes for a middleware", () => {
+    const calls: string[] = [];
+    const first = new FirstMiddleware("first", calls);
+    const manager = new MiddlewareManager();
+    const { consumer, proxy } = createMiddlewareConsumer();
+
+    manager
+      .globalExclude("/global")
+      .apply(first)
+      .disableGlobalExcludeRoutes()
+      .exclude("/local")
+      .forRoutes("/route");
+
+    manager.configure(consumer);
+
+    expect(proxy.exclude).toHaveBeenCalledWith("/local");
+    expect(proxy.exclude).not.toHaveBeenCalledWith("/global");
+  });
+
+  it("returns manager without registering middleware when no routes are provided", () => {
+    const calls: string[] = [];
+    const first = new FirstMiddleware("first", calls);
+    const manager = new MiddlewareManager();
+
+    expect(manager.apply(first).forRoutes()).toBe(manager);
+    expect(collectMiddlewares(manager)).toEqual([]);
+  });
+
+  it("delegates module configuration to the middleware manager", () => {
+    const configure = jest.fn();
+    const manager = {
+      configure,
+    } as unknown as MiddlewareManager;
+    const consumer = {} as MiddlewareConsumer;
+    const module = new MiddlewareModule(manager);
+
+    module.configure(consumer);
+
+    expect(configure).toHaveBeenCalledWith(consumer);
+  });
+});

--- a/packages/middleware/src/middleware.manager.ts
+++ b/packages/middleware/src/middleware.manager.ts
@@ -39,6 +39,48 @@ export class MiddlewareManager {
       }
     }
 
+    const resolveDependencyMiddleware = (
+      middlewareType: Type<NestMiddleware>,
+    ) => {
+      const middleware = typeToMiddleware.get(middlewareType);
+      if (!middleware) {
+        throw new Error(
+          `Dependency middleware ${middlewareType.name} is not registered`,
+        );
+      }
+      return middleware;
+    };
+
+    const dependencyMap = new Map<
+      MiddlewareInstanceOrFunction,
+      MiddlewareInstanceOrFunction[]
+    >();
+
+    for (const [middleware, config] of this.middlewareConfigMap) {
+      dependencyMap.set(
+        middleware,
+        config.dependencyMiddlewares.map((dependencyMiddleware) =>
+          resolveDependencyMiddleware(dependencyMiddleware),
+        ),
+      );
+    }
+
+    for (const [middleware, config] of this.middlewareConfigMap) {
+      for (const afterMiddleware of config.afterMiddlewares) {
+        const dependency = typeToMiddleware.get(afterMiddleware);
+        if (dependency) {
+          dependencyMap.get(middleware)?.push(dependency);
+        }
+      }
+
+      for (const beforeMiddleware of config.beforeMiddlewares) {
+        const dependent = typeToMiddleware.get(beforeMiddleware);
+        if (dependent) {
+          dependencyMap.get(dependent)?.push(middleware);
+        }
+      }
+    }
+
     const visit = (middleware: MiddlewareInstanceOrFunction) => {
       if (visited.has(middleware)) {
         return;
@@ -50,17 +92,9 @@ export class MiddlewareManager {
 
       visiting.add(middleware);
 
-      const config = this.middlewareConfigMap.get(middleware);
-      if (config?.dependencyMiddlewares) {
-        for (const dependencyMiddleware of config.dependencyMiddlewares) {
-          const depMiddleware = typeToMiddleware.get(dependencyMiddleware);
-          if (!depMiddleware) {
-            throw new Error(
-              `Dependency middleware ${dependencyMiddleware.name} is not registered`,
-            );
-          }
-          visit(depMiddleware);
-        }
+      const dependencies = dependencyMap.get(middleware) ?? [];
+      for (const dependency of dependencies) {
+        visit(dependency);
       }
 
       visiting.delete(middleware);


### PR DESCRIPTION
## Summary

- Add `before(...)` and `after(...)` as soft middleware ordering hints.
- Keep `dependencies(...)` as a hard prerequisite that requires the target middleware to be registered and run first.
- Cover ordering, missing-target behavior, cycles, route exclusions, function middleware, module delegation, and package exports with unit tests.
- Update middleware tutorial docs in English and Simplified Chinese, plus add a changeset for `@nest-boot/middleware`.

Fixes #245.

## Validation

- `pnpm --filter @nest-boot/middleware exec jest --coverage --runInBand`
- `pnpm --filter @nest-boot/middleware build`
- `pnpm --filter @nest-boot/middleware exec eslint "src/**/*.ts" --max-warnings=0`
- `pnpm --filter @nest-boot/middleware exec tsc -p tsconfig.json --noEmit`
- `pnpm typedoc:check`
- `pnpm docs:generate`
- `pnpm --filter @nest-boot/docs types:check`
- `git diff --check`

Commit hook also ran `lint-staged && pnpm docs:check`.