### PR TITLE
fix: RLS policy name truncation

### DIFF
--- a/.changeset/stable-rls-policy-names.md
+++ b/.changeset/stable-rls-policy-names.md
@@ -1,0 +1,5 @@
+---
+"@nest-boot/row-level-security": patch
+---
+
+Shorten generated PostgreSQL row-level security policy names before migration diffing to avoid redundant policy recreation when names exceed the identifier length limit.

--- a/packages/row-level-security/src/interfaces/row-level-security-migration-generator.interface.ts
+++ b/packages/row-level-security/src/interfaces/row-level-security-migration-generator.interface.ts
@@ -45,6 +45,7 @@ export interface DatabaseConnectionLike {
 
 export interface RowLevelSecurityMigrationGeneratorDriverLike {
   config?: {
+    get?: (key: string) => unknown;
     getMetadata?: () => MetadataStorageLike;
   };
   getConnection?: () => DatabaseConnectionLike;
@@ -53,6 +54,8 @@ export interface RowLevelSecurityMigrationGeneratorDriverLike {
 
 export interface RowLevelSecurityDefinition extends PolicySqlOptions {
   entityName: string;
+  /** Database policy names treated as equivalent when diffing existing policies. */
+  policyNameAliases?: string[];
   bootstrapSql?: string[];
 }
 

--- a/packages/row-level-security/src/row-level-security-migration-generator.spec.ts
+++ b/packages/row-level-security/src/row-level-security-migration-generator.spec.ts
@@ -45,6 +45,14 @@ class WorkspaceMemberWithGeneratedPolicy {}
 class WorkspaceMemberWithWorkspaceContextPolicy {}
 
 @Policy({
+  command: PolicyCommand.ALL,
+  property: "workspace",
+  context: "workspace_id",
+  roles: ["authenticated"],
+})
+class WorkspaceMemberGroupMemberWithLongGeneratedPolicy {}
+
+@Policy({
   name: "audit_log_select_policy",
   command: PolicyCommand.SELECT,
   using: "true",
@@ -80,6 +88,20 @@ const WORKSPACE_MEMBER_FIELD_CHANGE_DIFF = {
   up: ['alter table "workspace_member" add column "display_name" text null;'],
   down: ['alter table "workspace_member" drop column "display_name";'],
 };
+const WORKSPACE_MEMBER_GROUP_MEMBER_FIELD_CHANGE_DIFF = {
+  up: [
+    'alter table "workspace_member_group_member" add column "display_name" text null;',
+  ],
+  down: [
+    'alter table "workspace_member_group_member" drop column "display_name";',
+  ],
+};
+const LONG_GENERATED_POLICY_NAME =
+  "workspace_member_group_member_workspace_all_authenticated_policy";
+const LONG_GENERATED_POLICY_NAME_POSTGRES_TRUNCATED =
+  "workspace_member_group_member_workspace_all_authenticated_polic";
+const LONG_GENERATED_POLICY_NAME_SHORTENED =
+  "workspace_member_group_member_workspace_all_authe_fb4ec_policy";
 
 describe("RowLevelSecurityMigrationGenerator", () => {
   afterEach(() => {
@@ -374,6 +396,57 @@ describe("RowLevelSecurityMigrationGenerator", () => {
     );
     expect(file).toContain("extends Migration");
     expect(file).not.toContain("workspace_member_user_select_policy");
+  });
+
+  it("does not recreate unchanged generated policies with legacy PostgreSQL-truncated names", async () => {
+    const execute = jest.fn((_sql: string) =>
+      Promise.resolve([
+        {
+          policy_name: LONG_GENERATED_POLICY_NAME_POSTGRES_TRUNCATED,
+          schema_name: "public",
+          table_name: "workspace_member_group_member",
+          permissive: true,
+          command: "*",
+          qual: "(( SELECT app.get_context('workspace_id'::text, NULL::bigint) AS get_context) = workspace_id)",
+          with_check:
+            "(( SELECT app.get_context('workspace_id'::text, NULL::bigint) AS get_context) = workspace_id)",
+          roles: ["authenticated"],
+        },
+      ]),
+    );
+    const generator = createGenerator(
+      [
+        {
+          class: WorkspaceMemberGroupMemberWithLongGeneratedPolicy,
+          tableName: "workspace_member_group_member",
+          properties: {
+            workspace: {
+              fieldNames: ["workspace_id"],
+              columnTypes: ["bigint"],
+            },
+          },
+        },
+      ],
+      {
+        getConnection: () => ({
+          execute,
+        }),
+      },
+    );
+
+    mockBaseMigrationGenerate(WORKSPACE_MEMBER_GROUP_MEMBER_FIELD_CHANGE_DIFF);
+
+    const [file] = await generator.generate(
+      WORKSPACE_MEMBER_GROUP_MEMBER_FIELD_CHANGE_DIFF,
+    );
+
+    expect(file).toContain(
+      'alter table "workspace_member_group_member" add column "display_name" text null;',
+    );
+    expect(file).toContain("extends Migration");
+    expect(file).not.toContain(LONG_GENERATED_POLICY_NAME_POSTGRES_TRUNCATED);
+    expect(file).not.toContain(LONG_GENERATED_POLICY_NAME);
+    expect(file).not.toContain(LONG_GENERATED_POLICY_NAME_SHORTENED);
   });
 
   it.each([
@@ -904,6 +977,35 @@ describe("RowLevelSecurityMigrationGenerator", () => {
     expect(file).toContain(
       'this.addSql(`create policy workspace_member_user_select_policy on "public"."workspace_member" as permissive for select using (( SELECT app.get_context(\'user_id\'::text, NULL::bigint) AS get_context) = user_id);`);',
     );
+  });
+
+  it("shortens generated policy names longer than PostgreSQL identifier limit", () => {
+    const generator = createGenerator([
+      {
+        class: WorkspaceMemberGroupMemberWithLongGeneratedPolicy,
+        tableName: "workspace_member_group_member",
+        properties: {
+          workspace: {
+            fieldNames: ["workspace_id"],
+            columnTypes: ["bigint"],
+          },
+        },
+      },
+    ]);
+
+    const file = generator.generateMigrationFile("MigrationTest", {
+      up: [],
+      down: [],
+    });
+
+    expect(LONG_GENERATED_POLICY_NAME_SHORTENED).toHaveLength(62);
+    expect(file).toContain(
+      `create policy ${LONG_GENERATED_POLICY_NAME_SHORTENED}`,
+    );
+    expect(file).toContain(
+      `drop policy if exists ${LONG_GENERATED_POLICY_NAME_SHORTENED}`,
+    );
+    expect(file).not.toContain(LONG_GENERATED_POLICY_NAME);
   });
 
   it("canonicalizes generated policy context type aliases", () => {

--- a/packages/row-level-security/src/row-level-security-migration-generator.ts
+++ b/packages/row-level-security/src/row-level-security-migration-generator.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { TSMigrationGenerator } from "@mikro-orm/migrations";
 
 import { getPolicyDefinitions } from "./decorators/policy.decorator";
@@ -23,6 +25,11 @@ import {
 import { createPolicyUpSqlStatements } from "./utils/create-policy-up-sql-statements";
 import { isPostgresKeywordRequiringQuote } from "./utils/is-postgres-keyword-requiring-quote";
 import { normalizePostgresTypeAlias } from "./utils/normalize-postgres-type-alias";
+
+const POSTGRES_IDENTIFIER_MAX_LENGTH = 63;
+const POLICY_IDENTIFIER_TYPE = "policy";
+
+type HashAlgorithm = "md5" | "sha256";
 
 /** MikroORM TypeScript migration generator that injects generated RLS SQL. */
 export class RowLevelSecurityMigrationGenerator extends TSMigrationGenerator {
@@ -201,6 +208,8 @@ export class RowLevelSecurityMigrationGenerator extends TSMigrationGenerator {
   private getPolicyDefinitions(
     metadata = this.getEntityMetadata(),
   ): RowLevelSecurityDefinition[] {
+    const hashAlgorithm = this.getHashAlgorithm();
+
     return sortPolicyDefinitions(
       metadata.flatMap((entityMetadata) => {
         if (!entityMetadata.class) {
@@ -220,20 +229,36 @@ export class RowLevelSecurityMigrationGenerator extends TSMigrationGenerator {
         return getPolicyDefinitions(
           entityMetadata.class,
           policyEntityMetadata,
-        ).map((policy) => ({
-          entityName,
-          schemaName,
-          tableName,
-          policyName: policy.name,
-          mode: policy.mode,
-          command: policy.command,
-          using: policy.using,
-          withCheck: policy.withCheck,
-          roles: policy.roles,
-          bootstrapSql: policy.bootstrapSql,
-        }));
+        ).map((policy) => {
+          const policyName = normalizePostgresPolicyName(
+            policy.name,
+            hashAlgorithm,
+          );
+
+          return {
+            entityName,
+            schemaName,
+            tableName,
+            policyName,
+            policyNameAliases: createPolicyNameAliases(policy.name, policyName),
+            mode: policy.mode,
+            command: policy.command,
+            using: policy.using,
+            withCheck: policy.withCheck,
+            roles: policy.roles,
+            bootstrapSql: policy.bootstrapSql,
+          };
+        });
       }),
     );
+  }
+
+  private getHashAlgorithm(): HashAlgorithm {
+    const driver = this
+      .driver as unknown as RowLevelSecurityMigrationGeneratorDriverLike;
+    const hashAlgorithm = driver.config?.get?.("hashAlgorithm");
+
+    return hashAlgorithm === "md5" ? "md5" : "sha256";
   }
 
   private getEntityMetadata() {
@@ -393,10 +418,33 @@ function hasPolicyDefinitionWithSameContent(
 ) {
   return definitions.some(
     (candidate) =>
-      getPolicyDefinitionKey(candidate) ===
-        getPolicyDefinitionKey(definition) &&
+      hasSamePolicyDefinitionIdentity(candidate, definition) &&
       hasSamePolicyDefinitionContent(candidate, definition),
   );
+}
+
+function hasSamePolicyDefinitionIdentity(
+  left: RowLevelSecurityDefinition,
+  right: RowLevelSecurityDefinition,
+) {
+  return (
+    left.schemaName === right.schemaName &&
+    left.tableName === right.tableName &&
+    hasOverlappingPolicyNames(left, right)
+  );
+}
+
+function hasOverlappingPolicyNames(
+  left: RowLevelSecurityDefinition,
+  right: RowLevelSecurityDefinition,
+) {
+  const leftNames = new Set(getPolicyNameAliases(left));
+
+  return getPolicyNameAliases(right).some((name) => leftNames.has(name));
+}
+
+function getPolicyNameAliases(definition: RowLevelSecurityDefinition) {
+  return definition.policyNameAliases ?? [definition.policyName];
 }
 
 function hasSamePolicyDefinitionContent(
@@ -929,6 +977,42 @@ function getPolicyDefinitionKey(definition: RowLevelSecurityDefinition) {
     definition.tableName,
     definition.policyName,
   ].join(".");
+}
+
+function normalizePostgresPolicyName(
+  policyName: string,
+  hashAlgorithm: HashAlgorithm,
+) {
+  if (policyName.length <= POSTGRES_IDENTIFIER_MAX_LENGTH) {
+    return policyName;
+  }
+
+  return [
+    policyName.substring(0, 55 - POLICY_IDENTIFIER_TYPE.length),
+    hashValue(policyName, 5, hashAlgorithm),
+    POLICY_IDENTIFIER_TYPE,
+  ].join("_");
+}
+
+function createPolicyNameAliases(policyName: string, normalizedName: string) {
+  const aliases = new Set([normalizedName]);
+
+  if (policyName.length > POSTGRES_IDENTIFIER_MAX_LENGTH) {
+    aliases.add(policyName.substring(0, POSTGRES_IDENTIFIER_MAX_LENGTH));
+  }
+
+  return [...aliases];
+}
+
+function hashValue(
+  value: string,
+  length: number,
+  hashAlgorithm: HashAlgorithm,
+) {
+  return createHash(hashAlgorithm)
+    .update(value)
+    .digest("hex")
+    .substring(0, length);
 }
 
 function createPolicyDefinitionFromPolicyRow(


### PR DESCRIPTION
## Summary

- Shorten generated PostgreSQL RLS policy names before migration diffing when they exceed the 63-character identifier limit.
- Match existing database policies against both the new hashed policy name and legacy PostgreSQL-truncated names, avoiding repeated drop/create migrations for unchanged policies.
- Add regression coverage for long generated policy names and legacy truncated names.
- Add a patch changeset for `@nest-boot/row-level-security`.

## Root Cause

PostgreSQL silently truncates identifiers longer than 63 characters. The RLS migration generator compared metadata policy names against database policy names directly, so long generated policy names could appear changed on every migration generation.

## Validation

- `pnpm exec prettier --check .changeset/stable-rls-policy-names.md packages/row-level-security/src/row-level-security-migration-generator.ts packages/row-level-security/src/row-level-security-migration-generator.spec.ts packages/row-level-security/src/interfaces/row-level-security-migration-generator.interface.ts`
- `pnpm --filter @nest-boot/row-level-security build`
- `pnpm --filter @nest-boot/row-level-security exec jest src --runInBand`
- `pnpm changeset status --since=origin/master`
- commit hook: `lint-staged && pnpm docs:check`

## Notes

`pnpm --filter @nest-boot/row-level-security exec jest --runInBand` still requires database configuration for `test/row-level-security-e2e.spec.ts`; in this environment it fails with `No database specified, please fill in dbName or clientUrl option` while the 8 `src` test suites pass.