### PR TITLE
fix: graphql args type metadata

### DIFF
--- a/.changeset/curly-buckets-smile.md
+++ b/.changeset/curly-buckets-smile.md
@@ -1,0 +1,5 @@
+---
+"@nest-boot/graphql": patch
+---
+
+Document `ArgsType` explicit names and avoid depending on the internal `ClassType` enum export.

--- a/packages/graphql/src/decorators/args-type.decorator.ts
+++ b/packages/graphql/src/decorators/args-type.decorator.ts
@@ -1,10 +1,17 @@
-import { ClassType } from "@nestjs/graphql/dist/enums/class-type.enum";
 import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
 import { TypeMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/type-metadata.storage";
 import { addClassTypeMetadata } from "@nestjs/graphql/dist/utils/add-class-type-metadata.util";
 
 /**
  * Decorator that marks a class as a resolver arguments type.
+ *
+ * @param name - Optional GraphQL args type name. Use this for dynamically
+ * generated classes or classes whose TypeScript names are not unique.
+ *
+ * @remarks
+ * This extends NestJS' `ArgsType` behavior by allowing an explicit GraphQL
+ * metadata name. When omitted, the class name is used, matching NestJS'
+ * default behavior.
  *
  * @public
  */
@@ -21,6 +28,9 @@ export function ArgsType(name?: string): ClassDecorator {
     // This function must be called eagerly to allow resolvers
     // accessing the "name" property
     TypeMetadataStorage.addArgsMetadata(metadata);
-    addClassTypeMetadata(target, ClassType.ARGS);
+    addClassTypeMetadata(
+      target,
+      "args" as Parameters<typeof addClassTypeMetadata>[1],
+    );
   };
 }


### PR DESCRIPTION
## Summary

- Document the explicit `ArgsType(name)` support for generated args classes.
- Avoid importing NestJS' internal `ClassType` enum directly while preserving args class metadata registration.
- Add a patch changeset for `@nest-boot/graphql`.

## Why

`ArgsType` intentionally extends NestJS behavior so dynamically generated args classes can use stable GraphQL names. The direct `ClassType` deep import is brittle across `@nestjs/graphql` versions, so this keeps the metadata value localized to the `addClassTypeMetadata` parameter type.

## Verification

- `pnpm --filter @nest-boot/graphql build`
- commit hook: `lint-staged && pnpm docs:check`
- `pnpm changeset status --since=origin/master`