### PR TITLE
ci: use npm trusted publishing for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,4 +19,3 @@ jobs:
       release: true
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      NPM_ACCESS_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -12,8 +12,6 @@ on:
     secrets:
       CODECOV_TOKEN:
         required: false
-      NPM_ACCESS_TOKEN:
-        required: false
 
 jobs:
   verify:
@@ -126,5 +124,4 @@ jobs:
         run: pnpm exec nx release --yes
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary
- remove npm token plumbing from the reusable release workflow
- let npm CLI use GitHub Actions OIDC trusted publishing for package publishes
- keep provenance enabled for Nx release publishing

## Notes
- npm Trusted Publisher should be configured for the calling workflow filename: `release.yml`
- GitHub release writes still rely on `${{ github.token }}` with the updated repository ruleset bypass

## Testing
- `git diff --check`
- commit hook ran `pnpm build:packages` and `pnpm typedoc:check`
