### PR TITLE
feat(auth): support env-configured auth providers

### DIFF
--- a/apps/docs/content/docs/tutorial/auth.mdx
+++ b/apps/docs/content/docs/tutorial/auth.mdx
@@ -37,7 +37,35 @@ The module automatically:
 - Creates a better-auth instance with MikroORM adapter
 - Registers auth API routes at `/api/auth/` (configurable via `basePath`)
 - Registers auth middleware on all routes for session resolution
-- Reads `AUTH_SECRET` or `APP_SECRET` from environment variables
+- Reads common auth settings from environment variables
+
+### Environment Variables
+
+`AuthModule` can configure the default better-auth instance from environment variables. Values passed through `AuthModule.forRoot()` or `AuthModule.forRootAsync()` still take precedence for the matching better-auth options.
+
+| Variable                    | Description                                                                                                                  | Default                              |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| `AUTH_SECRET`               | Auth secret used to sign and encrypt auth data. Falls back to `APP_SECRET`. Must be at least 32 characters and high entropy. | Required                             |
+| `APP_SECRET`                | Fallback auth secret when `AUTH_SECRET` is not set.                                                                          | Required when `AUTH_SECRET` is unset |
+| `APP_NAME`                  | App name passed to better-auth.                                                                                              | unset                                |
+| `AUTH_URL`                  | Public auth base URL. Falls back to `APP_URL`.                                                                               | unset                                |
+| `APP_URL`                   | Fallback public base URL when `AUTH_URL` is not set.                                                                         | unset                                |
+| `AUTH_EMAIL_ENABLED`        | Set to `false` to disable email/password auth.                                                                               | enabled                              |
+| `AUTH_EMAIL_DISABLE_SIGNUP` | Set to `true` to disable signup through email/password auth.                                                                 | signup enabled                       |
+| `AUTH_DISABLE_SIGNUP`       | Set to `true` to disable signup for both email/password and OIDC auth.                                                       | signup enabled                       |
+
+When any `AUTH_OIDC_*` variable is set, `AuthModule` registers a `genericOAuth` provider with `providerId: "oidc"`. In that case, the following variables are validated at startup:
+
+| Variable                   | Description                                                                                                                                | Default                               |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------- |
+| `AUTH_OIDC_CLIENT_ID`      | OIDC client ID.                                                                                                                            | Required when OIDC env config is used |
+| `AUTH_OIDC_CLIENT_SECRET`  | OIDC client secret.                                                                                                                        | Required when OIDC env config is used |
+| `AUTH_OIDC_DISCOVERY_URL`  | OIDC discovery document URL.                                                                                                               | Required when OIDC env config is used |
+| `AUTH_OIDC_PROMPT`         | Optional OIDC prompt. Supported values: `none`, `login`, `create`, `consent`, `select_account`, `select_account consent`, `login consent`. | unset                                 |
+| `AUTH_OIDC_SCOPES`         | Comma-separated OIDC scopes.                                                                                                               | `openid,profile,email`                |
+| `AUTH_OIDC_DISABLE_SIGNUP` | Set to `true` to disable signup through OIDC.                                                                                              | signup enabled                        |
+
+If OIDC is not needed, leave all `AUTH_OIDC_*` variables unset. If you need multiple providers or custom provider behavior, configure `plugins` manually; env-configured OIDC is appended before custom plugins.
 
 ### Async Registration with OIDC
 
@@ -91,8 +119,8 @@ const AuthDynamicModule = AuthModule.forRootAsync({
         config: [
           {
             providerId: "oidc",
-            clientId: configService.getOrThrow("AUTH_OIDC_ID"),
-            clientSecret: configService.getOrThrow("AUTH_OIDC_SECRET"),
+            clientId: configService.getOrThrow("AUTH_OIDC_CLIENT_ID"),
+            clientSecret: configService.getOrThrow("AUTH_OIDC_CLIENT_SECRET"),
             discoveryUrl: configService.getOrThrow("AUTH_OIDC_DISCOVERY_URL"),
             prompt: "login",
             scopes: ["openid", "profile", "email"],

--- a/apps/docs/content/docs/tutorial/auth.mdx
+++ b/apps/docs/content/docs/tutorial/auth.mdx
@@ -41,7 +41,7 @@ The module automatically:
 
 ### Environment Variables
 
-`AuthModule` can configure the default better-auth instance from environment variables. Values passed through `AuthModule.forRoot()` or `AuthModule.forRootAsync()` still take precedence for the matching better-auth options.
+`AuthModule` can configure the default better-auth instance from environment variables. Values passed through `AuthModule.forRoot()` or `AuthModule.forRootAsync()` are merged with these defaults; signup-disable environment variables are preserved when nested auth options are supplied.
 
 | Variable                    | Description                                                                                                                  | Default                              |
 | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
@@ -50,9 +50,9 @@ The module automatically:
 | `APP_NAME`                  | App name passed to better-auth.                                                                                              | unset                                |
 | `AUTH_URL`                  | Public auth base URL. Falls back to `APP_URL`.                                                                               | unset                                |
 | `APP_URL`                   | Fallback public base URL when `AUTH_URL` is not set.                                                                         | unset                                |
-| `AUTH_EMAIL_ENABLED`        | Set to `false` to disable email/password auth.                                                                               | enabled                              |
-| `AUTH_EMAIL_DISABLE_SIGNUP` | Set to `true` to disable signup through email/password auth.                                                                 | signup enabled                       |
-| `AUTH_DISABLE_SIGNUP`       | Set to `true` to disable signup for both email/password and OIDC auth.                                                       | signup enabled                       |
+| `AUTH_EMAIL_ENABLED`        | Set to `true` or `false` to configure email/password auth explicitly.                                                        | better-auth default                  |
+| `AUTH_EMAIL_DISABLE_SIGNUP` | Set to `true` to disable signup through email/password auth when email/password auth is configured.                          | signup enabled                       |
+| `AUTH_DISABLE_SIGNUP`       | Set to `true` to disable signup for both configured email/password and OIDC auth.                                            | signup enabled                       |
 
 When any `AUTH_OIDC_*` variable is set, `AuthModule` registers a `genericOAuth` provider with `providerId: "oidc"`. In that case, the following variables are validated at startup:
 

--- a/apps/docs/content/docs/tutorial/auth.mdx
+++ b/apps/docs/content/docs/tutorial/auth.mdx
@@ -52,7 +52,20 @@ The module automatically:
 | `APP_URL`                   | Fallback public base URL when `AUTH_URL` is not set.                                                                         | unset                                |
 | `AUTH_EMAIL_ENABLED`        | Set to `true` or `false` to configure email/password auth explicitly.                                                        | better-auth default                  |
 | `AUTH_EMAIL_DISABLE_SIGNUP` | Set to `true` to disable signup through email/password auth when email/password auth is configured.                          | signup enabled                       |
-| `AUTH_DISABLE_SIGNUP`       | Set to `true` to disable signup for both configured email/password and OIDC auth.                                            | signup enabled                       |
+| `AUTH_DISABLE_SIGNUP`       | Set to `true` to disable signup for configured email/password, OIDC, Google, and GitHub auth.                                | signup enabled                       |
+
+When Google or GitHub credential variables are set, `AuthModule` configures the corresponding better-auth `socialProviders.google` or `socialProviders.github` provider. In that case, provider credentials are validated at startup:
+
+| Variable                     | Description                                     | Default                                 |
+| ---------------------------- | ----------------------------------------------- | --------------------------------------- |
+| `AUTH_GOOGLE_CLIENT_ID`      | Google OAuth client ID.                         | Required when Google env config is used |
+| `AUTH_GOOGLE_CLIENT_SECRET`  | Google OAuth client secret.                     | Required when Google env config is used |
+| `AUTH_GOOGLE_DISABLE_SIGNUP` | Set to `true` to disable signup through Google. | signup enabled                          |
+| `AUTH_GITHUB_CLIENT_ID`      | GitHub OAuth client ID.                         | Required when GitHub env config is used |
+| `AUTH_GITHUB_CLIENT_SECRET`  | GitHub OAuth client secret.                     | Required when GitHub env config is used |
+| `AUTH_GITHUB_DISABLE_SIGNUP` | Set to `true` to disable signup through GitHub. | signup enabled                          |
+
+Leave all provider-specific variables unset to keep that provider disabled. If you pass `socialProviders.google` or `socialProviders.github` manually, signup-disable env flags are still merged into the nested provider config without requiring credentials to move into env.
 
 When any `AUTH_OIDC_*` variable is set, `AuthModule` registers a `genericOAuth` provider with `providerId: "oidc"`. In that case, the following variables are validated at startup:
 
@@ -65,7 +78,7 @@ When any `AUTH_OIDC_*` variable is set, `AuthModule` registers a `genericOAuth` 
 | `AUTH_OIDC_SCOPES`         | Comma-separated OIDC scopes.                                                                                                               | `openid,profile,email`                |
 | `AUTH_OIDC_DISABLE_SIGNUP` | Set to `true` to disable signup through OIDC.                                                                                              | signup enabled                        |
 
-If OIDC is not needed, leave all `AUTH_OIDC_*` variables unset. If you need multiple providers or custom provider behavior, configure `plugins` manually; env-configured OIDC is appended before custom plugins.
+If OIDC is not needed, leave all `AUTH_OIDC_*` variables unset. If you need multiple generic OIDC providers or custom provider behavior, configure `plugins` manually; env-configured OIDC is appended before custom plugins.
 
 ### Async Registration with OIDC
 

--- a/apps/docs/content/docs/tutorial/auth.mdx
+++ b/apps/docs/content/docs/tutorial/auth.mdx
@@ -54,31 +54,34 @@ The module automatically:
 | `AUTH_EMAIL_DISABLE_SIGNUP` | Set to `true` to disable signup through email/password auth when email/password auth is configured.                          | signup enabled                       |
 | `AUTH_DISABLE_SIGNUP`       | Set to `true` to disable signup for configured email/password, OIDC, Google, and GitHub auth.                                | signup enabled                       |
 
-When Google or GitHub credential variables are set, `AuthModule` configures the corresponding better-auth `socialProviders.google` or `socialProviders.github` provider. In that case, provider credentials are validated at startup:
+Google and GitHub are disabled by default. Set `AUTH_GOOGLE_ENABLED=true` or `AUTH_GITHUB_ENABLED=true` to configure the corresponding better-auth `socialProviders.google` or `socialProviders.github` provider from env. In that case, provider credentials are validated at startup:
 
 | Variable                     | Description                                     | Default                                 |
 | ---------------------------- | ----------------------------------------------- | --------------------------------------- |
+| `AUTH_GOOGLE_ENABLED`        | Set to `true` to enable Google auth from env.   | disabled                                |
 | `AUTH_GOOGLE_CLIENT_ID`      | Google OAuth client ID.                         | Required when Google env config is used |
 | `AUTH_GOOGLE_CLIENT_SECRET`  | Google OAuth client secret.                     | Required when Google env config is used |
 | `AUTH_GOOGLE_DISABLE_SIGNUP` | Set to `true` to disable signup through Google. | signup enabled                          |
+| `AUTH_GITHUB_ENABLED`        | Set to `true` to enable GitHub auth from env.   | disabled                                |
 | `AUTH_GITHUB_CLIENT_ID`      | GitHub OAuth client ID.                         | Required when GitHub env config is used |
 | `AUTH_GITHUB_CLIENT_SECRET`  | GitHub OAuth client secret.                     | Required when GitHub env config is used |
 | `AUTH_GITHUB_DISABLE_SIGNUP` | Set to `true` to disable signup through GitHub. | signup enabled                          |
 
-Leave all provider-specific variables unset to keep that provider disabled. If you pass `socialProviders.google` or `socialProviders.github` manually, signup-disable env flags are still merged into the nested provider config without requiring credentials to move into env.
+Leave `AUTH_GOOGLE_ENABLED` or `AUTH_GITHUB_ENABLED` unset to keep that env provider disabled, even if credentials are present. If you pass `socialProviders.google` or `socialProviders.github` manually, explicit `*_ENABLED=false` and signup-disable env flags are still merged into the nested provider config without requiring credentials to move into env.
 
-When any `AUTH_OIDC_*` variable is set, `AuthModule` registers a `genericOAuth` provider with `providerId: "oidc"`. In that case, the following variables are validated at startup:
+Generic OIDC is also disabled by default. Set `AUTH_OIDC_ENABLED=true` to register a `genericOAuth` provider with `providerId: "oidc"`. In that case, the following variables are validated at startup:
 
 | Variable                   | Description                                                                                                                                | Default                               |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------- |
+| `AUTH_OIDC_ENABLED`        | Set to `true` to enable generic OIDC auth from env.                                                                                        | disabled                              |
 | `AUTH_OIDC_CLIENT_ID`      | OIDC client ID.                                                                                                                            | Required when OIDC env config is used |
 | `AUTH_OIDC_CLIENT_SECRET`  | OIDC client secret.                                                                                                                        | Required when OIDC env config is used |
 | `AUTH_OIDC_DISCOVERY_URL`  | OIDC discovery document URL.                                                                                                               | Required when OIDC env config is used |
 | `AUTH_OIDC_PROMPT`         | Optional OIDC prompt. Supported values: `none`, `login`, `create`, `consent`, `select_account`, `select_account consent`, `login consent`. | unset                                 |
-| `AUTH_OIDC_SCOPES`         | Comma-separated OIDC scopes.                                                                                                               | `openid,profile,email`                |
+| `AUTH_OIDC_SCOPES`         | Comma-separated OIDC scopes. Whitespace is trimmed and empty entries are ignored.                                                          | `openid,profile,email`                |
 | `AUTH_OIDC_DISABLE_SIGNUP` | Set to `true` to disable signup through OIDC.                                                                                              | signup enabled                        |
 
-If OIDC is not needed, leave all `AUTH_OIDC_*` variables unset. If you need multiple generic OIDC providers or custom provider behavior, configure `plugins` manually; env-configured OIDC is appended before custom plugins.
+If OIDC is not needed, leave `AUTH_OIDC_ENABLED` unset. If you need multiple generic OIDC providers or custom provider behavior, configure `plugins` manually; `AUTH_OIDC_*` cannot be combined with a custom `genericOAuth` plugin because better-auth registers one shared set of OAuth2 endpoints for that plugin.
 
 ### Async Registration with OIDC
 

--- a/apps/docs/content/docs/tutorial/auth.zh-Hans.mdx
+++ b/apps/docs/content/docs/tutorial/auth.zh-Hans.mdx
@@ -52,7 +52,20 @@ const AuthDynamicModule = AuthModule.forRoot({
 | `APP_URL`                   | 未设置 `AUTH_URL` 时使用的备用公开基础 URL。                                                | 未设置                     |
 | `AUTH_EMAIL_ENABLED`        | 设置为 `true` 或 `false` 时显式配置邮箱密码认证。                                           | better-auth 默认值         |
 | `AUTH_EMAIL_DISABLE_SIGNUP` | 设置为 `true` 时，在已配置邮箱密码认证的情况下禁用邮箱密码注册。                            | 允许注册                   |
-| `AUTH_DISABLE_SIGNUP`       | 设置为 `true` 时同时禁用已配置的邮箱密码和 OIDC 注册。                                      | 允许注册                   |
+| `AUTH_DISABLE_SIGNUP`       | 设置为 `true` 时禁用已配置的邮箱密码、OIDC、Google 和 GitHub 注册。                         | 允许注册                   |
+
+当设置了 Google 或 GitHub 凭据环境变量时，`AuthModule` 会配置对应的 better-auth `socialProviders.google` 或 `socialProviders.github` 专门 provider。此时模块会在启动时校验 provider 凭据：
+
+| 变量                         | 说明                               | 默认值                         |
+| ---------------------------- | ---------------------------------- | ------------------------------ |
+| `AUTH_GOOGLE_CLIENT_ID`      | Google OAuth 客户端 ID。           | 使用 Google 环境变量配置时必填 |
+| `AUTH_GOOGLE_CLIENT_SECRET`  | Google OAuth 客户端密钥。          | 使用 Google 环境变量配置时必填 |
+| `AUTH_GOOGLE_DISABLE_SIGNUP` | 设置为 `true` 时禁用 Google 注册。 | 允许注册                       |
+| `AUTH_GITHUB_CLIENT_ID`      | GitHub OAuth 客户端 ID。           | 使用 GitHub 环境变量配置时必填 |
+| `AUTH_GITHUB_CLIENT_SECRET`  | GitHub OAuth 客户端密钥。          | 使用 GitHub 环境变量配置时必填 |
+| `AUTH_GITHUB_DISABLE_SIGNUP` | 设置为 `true` 时禁用 GitHub 注册。 | 允许注册                       |
+
+如果不需要某个 provider，保持对应 provider 的环境变量未设置即可。如果手动传入了 `socialProviders.google` 或 `socialProviders.github`，禁用注册相关环境变量仍会合并到对应的嵌套 provider 配置中，不需要把凭据也移动到环境变量里。
 
 当设置了任意 `AUTH_OIDC_*` 变量时，`AuthModule` 会注册一个 `providerId: "oidc"` 的 `genericOAuth` 提供商。此时模块会在启动时校验以下变量：
 
@@ -65,7 +78,7 @@ const AuthDynamicModule = AuthModule.forRoot({
 | `AUTH_OIDC_SCOPES`         | 逗号分隔的 OIDC scopes。                                                                                                        | `openid,profile,email`       |
 | `AUTH_OIDC_DISABLE_SIGNUP` | 设置为 `true` 时禁用 OIDC 注册。                                                                                                | 允许注册                     |
 
-如果不需要 OIDC，保持所有 `AUTH_OIDC_*` 变量未设置即可。如果需要多个 provider 或自定义 provider 行为，可以手动配置 `plugins`；通过环境变量配置的 OIDC 插件会追加在自定义插件之前。
+如果不需要 OIDC，保持所有 `AUTH_OIDC_*` 变量未设置即可。如果需要多个 generic OIDC provider 或自定义 provider 行为，可以手动配置 `plugins`；通过环境变量配置的 OIDC 插件会追加在自定义插件之前。
 
 ### 异步注册（含 OIDC）
 

--- a/apps/docs/content/docs/tutorial/auth.zh-Hans.mdx
+++ b/apps/docs/content/docs/tutorial/auth.zh-Hans.mdx
@@ -54,31 +54,34 @@ const AuthDynamicModule = AuthModule.forRoot({
 | `AUTH_EMAIL_DISABLE_SIGNUP` | 设置为 `true` 时，在已配置邮箱密码认证的情况下禁用邮箱密码注册。                            | 允许注册                   |
 | `AUTH_DISABLE_SIGNUP`       | 设置为 `true` 时禁用已配置的邮箱密码、OIDC、Google 和 GitHub 注册。                         | 允许注册                   |
 
-当设置了 Google 或 GitHub 凭据环境变量时，`AuthModule` 会配置对应的 better-auth `socialProviders.google` 或 `socialProviders.github` 专门 provider。此时模块会在启动时校验 provider 凭据：
+Google 和 GitHub 默认禁用。设置 `AUTH_GOOGLE_ENABLED=true` 或 `AUTH_GITHUB_ENABLED=true` 时，`AuthModule` 会从环境变量配置对应的 better-auth `socialProviders.google` 或 `socialProviders.github` 专门 provider。此时模块会在启动时校验 provider 凭据：
 
-| 变量                         | 说明                               | 默认值                         |
-| ---------------------------- | ---------------------------------- | ------------------------------ |
-| `AUTH_GOOGLE_CLIENT_ID`      | Google OAuth 客户端 ID。           | 使用 Google 环境变量配置时必填 |
-| `AUTH_GOOGLE_CLIENT_SECRET`  | Google OAuth 客户端密钥。          | 使用 Google 环境变量配置时必填 |
-| `AUTH_GOOGLE_DISABLE_SIGNUP` | 设置为 `true` 时禁用 Google 注册。 | 允许注册                       |
-| `AUTH_GITHUB_CLIENT_ID`      | GitHub OAuth 客户端 ID。           | 使用 GitHub 环境变量配置时必填 |
-| `AUTH_GITHUB_CLIENT_SECRET`  | GitHub OAuth 客户端密钥。          | 使用 GitHub 环境变量配置时必填 |
-| `AUTH_GITHUB_DISABLE_SIGNUP` | 设置为 `true` 时禁用 GitHub 注册。 | 允许注册                       |
+| 变量                         | 说明                                         | 默认值                         |
+| ---------------------------- | -------------------------------------------- | ------------------------------ |
+| `AUTH_GOOGLE_ENABLED`        | 设置为 `true` 时从环境变量启用 Google 认证。 | 禁用                           |
+| `AUTH_GOOGLE_CLIENT_ID`      | Google OAuth 客户端 ID。                     | 使用 Google 环境变量配置时必填 |
+| `AUTH_GOOGLE_CLIENT_SECRET`  | Google OAuth 客户端密钥。                    | 使用 Google 环境变量配置时必填 |
+| `AUTH_GOOGLE_DISABLE_SIGNUP` | 设置为 `true` 时禁用 Google 注册。           | 允许注册                       |
+| `AUTH_GITHUB_ENABLED`        | 设置为 `true` 时从环境变量启用 GitHub 认证。 | 禁用                           |
+| `AUTH_GITHUB_CLIENT_ID`      | GitHub OAuth 客户端 ID。                     | 使用 GitHub 环境变量配置时必填 |
+| `AUTH_GITHUB_CLIENT_SECRET`  | GitHub OAuth 客户端密钥。                    | 使用 GitHub 环境变量配置时必填 |
+| `AUTH_GITHUB_DISABLE_SIGNUP` | 设置为 `true` 时禁用 GitHub 注册。           | 允许注册                       |
 
-如果不需要某个 provider，保持对应 provider 的环境变量未设置即可。如果手动传入了 `socialProviders.google` 或 `socialProviders.github`，禁用注册相关环境变量仍会合并到对应的嵌套 provider 配置中，不需要把凭据也移动到环境变量里。
+如果不需要某个 env provider，保持 `AUTH_GOOGLE_ENABLED` 或 `AUTH_GITHUB_ENABLED` 未设置即可；即使设置了凭据，也不会启用。如果手动传入了 `socialProviders.google` 或 `socialProviders.github`，显式的 `*_ENABLED=false` 和禁用注册相关环境变量仍会合并到对应的嵌套 provider 配置中，不需要把凭据也移动到环境变量里。
 
-当设置了任意 `AUTH_OIDC_*` 变量时，`AuthModule` 会注册一个 `providerId: "oidc"` 的 `genericOAuth` 提供商。此时模块会在启动时校验以下变量：
+Generic OIDC 也默认禁用。设置 `AUTH_OIDC_ENABLED=true` 时，`AuthModule` 会注册一个 `providerId: "oidc"` 的 `genericOAuth` 提供商。此时模块会在启动时校验以下变量：
 
 | 变量                       | 说明                                                                                                                            | 默认值                       |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `AUTH_OIDC_ENABLED`        | 设置为 `true` 时从环境变量启用 generic OIDC 认证。                                                                              | 禁用                         |
 | `AUTH_OIDC_CLIENT_ID`      | OIDC 客户端 ID。                                                                                                                | 使用 OIDC 环境变量配置时必填 |
 | `AUTH_OIDC_CLIENT_SECRET`  | OIDC 客户端密钥。                                                                                                               | 使用 OIDC 环境变量配置时必填 |
 | `AUTH_OIDC_DISCOVERY_URL`  | OIDC discovery 文档 URL。                                                                                                       | 使用 OIDC 环境变量配置时必填 |
 | `AUTH_OIDC_PROMPT`         | 可选的 OIDC prompt。支持值：`none`、`login`、`create`、`consent`、`select_account`、`select_account consent`、`login consent`。 | 未设置                       |
-| `AUTH_OIDC_SCOPES`         | 逗号分隔的 OIDC scopes。                                                                                                        | `openid,profile,email`       |
+| `AUTH_OIDC_SCOPES`         | 逗号分隔的 OIDC scopes。会 trim 空白并忽略空项。                                                                                | `openid,profile,email`       |
 | `AUTH_OIDC_DISABLE_SIGNUP` | 设置为 `true` 时禁用 OIDC 注册。                                                                                                | 允许注册                     |
 
-如果不需要 OIDC，保持所有 `AUTH_OIDC_*` 变量未设置即可。如果需要多个 generic OIDC provider 或自定义 provider 行为，可以手动配置 `plugins`；通过环境变量配置的 OIDC 插件会追加在自定义插件之前。
+如果不需要 OIDC，保持 `AUTH_OIDC_ENABLED` 未设置即可。如果需要多个 generic OIDC provider 或自定义 provider 行为，可以手动配置 `plugins`；`AUTH_OIDC_*` 不能和自定义 `genericOAuth` 插件组合使用，因为 better-auth 会为该插件注册同一组 OAuth2 endpoints。
 
 ### 异步注册（含 OIDC）
 

--- a/apps/docs/content/docs/tutorial/auth.zh-Hans.mdx
+++ b/apps/docs/content/docs/tutorial/auth.zh-Hans.mdx
@@ -41,7 +41,7 @@ const AuthDynamicModule = AuthModule.forRoot({
 
 ### 环境变量
 
-`AuthModule` 可以从环境变量配置默认的 better-auth 实例。通过 `AuthModule.forRoot()` 或 `AuthModule.forRootAsync()` 传入的同名 better-auth 选项仍然优先。
+`AuthModule` 可以从环境变量配置默认的 better-auth 实例。通过 `AuthModule.forRoot()` 或 `AuthModule.forRootAsync()` 传入的选项会与这些默认值合并；即使传入了嵌套认证选项，环境变量中的禁用注册开关也会保留。
 
 | 变量                        | 说明                                                                                        | 默认值                     |
 | --------------------------- | ------------------------------------------------------------------------------------------- | -------------------------- |
@@ -50,9 +50,9 @@ const AuthDynamicModule = AuthModule.forRoot({
 | `APP_NAME`                  | 传给 better-auth 的应用名称。                                                               | 未设置                     |
 | `AUTH_URL`                  | 公开的认证基础 URL。未设置时回退到 `APP_URL`。                                              | 未设置                     |
 | `APP_URL`                   | 未设置 `AUTH_URL` 时使用的备用公开基础 URL。                                                | 未设置                     |
-| `AUTH_EMAIL_ENABLED`        | 设置为 `false` 时禁用邮箱密码认证。                                                         | 启用                       |
-| `AUTH_EMAIL_DISABLE_SIGNUP` | 设置为 `true` 时禁用邮箱密码注册。                                                          | 允许注册                   |
-| `AUTH_DISABLE_SIGNUP`       | 设置为 `true` 时同时禁用邮箱密码和 OIDC 注册。                                              | 允许注册                   |
+| `AUTH_EMAIL_ENABLED`        | 设置为 `true` 或 `false` 时显式配置邮箱密码认证。                                           | better-auth 默认值         |
+| `AUTH_EMAIL_DISABLE_SIGNUP` | 设置为 `true` 时，在已配置邮箱密码认证的情况下禁用邮箱密码注册。                            | 允许注册                   |
+| `AUTH_DISABLE_SIGNUP`       | 设置为 `true` 时同时禁用已配置的邮箱密码和 OIDC 注册。                                      | 允许注册                   |
 
 当设置了任意 `AUTH_OIDC_*` 变量时，`AuthModule` 会注册一个 `providerId: "oidc"` 的 `genericOAuth` 提供商。此时模块会在启动时校验以下变量：
 

--- a/apps/docs/content/docs/tutorial/auth.zh-Hans.mdx
+++ b/apps/docs/content/docs/tutorial/auth.zh-Hans.mdx
@@ -37,7 +37,35 @@ const AuthDynamicModule = AuthModule.forRoot({
 - 使用 MikroORM 适配器创建 better-auth 实例
 - 在 `/api/auth/` 注册认证 API 路由（可通过 `basePath` 配置）
 - 在所有路由上注册认证中间件用于会话解析
-- 从环境变量读取 `AUTH_SECRET` 或 `APP_SECRET`
+- 从环境变量读取常用认证配置
+
+### 环境变量
+
+`AuthModule` 可以从环境变量配置默认的 better-auth 实例。通过 `AuthModule.forRoot()` 或 `AuthModule.forRootAsync()` 传入的同名 better-auth 选项仍然优先。
+
+| 变量                        | 说明                                                                                        | 默认值                     |
+| --------------------------- | ------------------------------------------------------------------------------------------- | -------------------------- |
+| `AUTH_SECRET`               | 用于签名和加密认证数据的密钥。未设置时回退到 `APP_SECRET`。必须至少 32 个字符且具有高熵值。 | 必填                       |
+| `APP_SECRET`                | 未设置 `AUTH_SECRET` 时使用的备用认证密钥。                                                 | `AUTH_SECRET` 未设置时必填 |
+| `APP_NAME`                  | 传给 better-auth 的应用名称。                                                               | 未设置                     |
+| `AUTH_URL`                  | 公开的认证基础 URL。未设置时回退到 `APP_URL`。                                              | 未设置                     |
+| `APP_URL`                   | 未设置 `AUTH_URL` 时使用的备用公开基础 URL。                                                | 未设置                     |
+| `AUTH_EMAIL_ENABLED`        | 设置为 `false` 时禁用邮箱密码认证。                                                         | 启用                       |
+| `AUTH_EMAIL_DISABLE_SIGNUP` | 设置为 `true` 时禁用邮箱密码注册。                                                          | 允许注册                   |
+| `AUTH_DISABLE_SIGNUP`       | 设置为 `true` 时同时禁用邮箱密码和 OIDC 注册。                                              | 允许注册                   |
+
+当设置了任意 `AUTH_OIDC_*` 变量时，`AuthModule` 会注册一个 `providerId: "oidc"` 的 `genericOAuth` 提供商。此时模块会在启动时校验以下变量：
+
+| 变量                       | 说明                                                                                                                            | 默认值                       |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `AUTH_OIDC_CLIENT_ID`      | OIDC 客户端 ID。                                                                                                                | 使用 OIDC 环境变量配置时必填 |
+| `AUTH_OIDC_CLIENT_SECRET`  | OIDC 客户端密钥。                                                                                                               | 使用 OIDC 环境变量配置时必填 |
+| `AUTH_OIDC_DISCOVERY_URL`  | OIDC discovery 文档 URL。                                                                                                       | 使用 OIDC 环境变量配置时必填 |
+| `AUTH_OIDC_PROMPT`         | 可选的 OIDC prompt。支持值：`none`、`login`、`create`、`consent`、`select_account`、`select_account consent`、`login consent`。 | 未设置                       |
+| `AUTH_OIDC_SCOPES`         | 逗号分隔的 OIDC scopes。                                                                                                        | `openid,profile,email`       |
+| `AUTH_OIDC_DISABLE_SIGNUP` | 设置为 `true` 时禁用 OIDC 注册。                                                                                                | 允许注册                     |
+
+如果不需要 OIDC，保持所有 `AUTH_OIDC_*` 变量未设置即可。如果需要多个 provider 或自定义 provider 行为，可以手动配置 `plugins`；通过环境变量配置的 OIDC 插件会追加在自定义插件之前。
 
 ### 异步注册（含 OIDC）
 
@@ -91,8 +119,8 @@ const AuthDynamicModule = AuthModule.forRootAsync({
         config: [
           {
             providerId: "oidc",
-            clientId: configService.getOrThrow("AUTH_OIDC_ID"),
-            clientSecret: configService.getOrThrow("AUTH_OIDC_SECRET"),
+            clientId: configService.getOrThrow("AUTH_OIDC_CLIENT_ID"),
+            clientSecret: configService.getOrThrow("AUTH_OIDC_CLIENT_SECRET"),
             discoveryUrl: configService.getOrThrow("AUTH_OIDC_DISCOVERY_URL"),
             prompt: "login",
             scopes: ["openid", "profile", "email"],

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -58,7 +58,7 @@
     "@nest-boot/request-context": "^7.0.0",
     "@nestjs/common": "^11.0.0",
     "@nestjs/core": "^11.0.0",
-    "better-auth": "^1.0.0",
+    "better-auth": "^1.4.10",
     "express": "^5.0.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.0.0"

--- a/packages/auth/src/auth.module.spec.ts
+++ b/packages/auth/src/auth.module.spec.ts
@@ -16,12 +16,19 @@ const mockMikroOrmAdapter = jest.fn((options) => ({
   options,
   type: "mikro-orm-adapter",
 }));
+const mockGenericOAuth = jest.fn((options) => ({
+  options,
+  type: "generic-oauth",
+}));
 
 jest.mock("better-auth", () => ({
   betterAuth: mockBetterAuth,
 }));
 jest.mock("better-auth/node", () => ({
   toNodeHandler: mockToNodeHandler,
+}));
+jest.mock("better-auth/plugins", () => ({
+  genericOAuth: mockGenericOAuth,
 }));
 jest.mock("./adapters/mikro-orm-adapter", () => ({
   mikroOrmAdapter: mockMikroOrmAdapter,
@@ -43,6 +50,13 @@ const entities = {
   user: User,
   verification: Verification,
 };
+
+function setOidcEnv() {
+  process.env.AUTH_OIDC_CLIENT_ID = "oidc-client-id";
+  process.env.AUTH_OIDC_CLIENT_SECRET = "oidc-client-secret";
+  process.env.AUTH_OIDC_DISCOVERY_URL =
+    "https://oidc.example.com/.well-known/openid-configuration";
+}
 
 function getAuthProvider() {
   const providers = Reflect.getMetadata(
@@ -119,10 +133,21 @@ describe("AuthModule", () => {
 
   beforeEach(() => {
     mockBetterAuth.mockClear();
+    mockGenericOAuth.mockClear();
     mockMikroOrmAdapter.mockClear();
     mockToNodeHandler.mockClear();
+    delete process.env.APP_NAME;
     delete process.env.APP_SECRET;
     delete process.env.AUTH_SECRET;
+    delete process.env.AUTH_DISABLE_SIGNUP;
+    delete process.env.AUTH_EMAIL_ENABLED;
+    delete process.env.AUTH_EMAIL_DISABLE_SIGNUP;
+    delete process.env.AUTH_OIDC_CLIENT_ID;
+    delete process.env.AUTH_OIDC_CLIENT_SECRET;
+    delete process.env.AUTH_OIDC_DISCOVERY_URL;
+    delete process.env.AUTH_OIDC_DISABLE_SIGNUP;
+    delete process.env.AUTH_OIDC_PROMPT;
+    delete process.env.AUTH_OIDC_SCOPES;
     delete process.env.APP_URL;
     delete process.env.AUTH_URL;
   });
@@ -204,6 +229,169 @@ describe("AuthModule", () => {
         },
         entities,
         secret,
+      }),
+    );
+  });
+
+  it("should disable email and OIDC signup when the global signup disable flag is enabled", () => {
+    process.env.AUTH_DISABLE_SIGNUP = "true";
+    setOidcEnv();
+    const orm = {
+      em: {},
+    } as unknown as MikroORM;
+    const authProvider = getAuthProvider();
+
+    authProvider.useFactory(
+      {
+        entities,
+        secret,
+      },
+      orm,
+    );
+
+    expect(mockBetterAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailAndPassword: expect.objectContaining({
+          disableSignUp: true,
+        }),
+      }),
+    );
+    expect(mockGenericOAuth).toHaveBeenCalledWith({
+      config: [
+        expect.objectContaining({
+          disableSignUp: true,
+          providerId: "oidc",
+        }),
+      ],
+    });
+  });
+
+  it("should keep signup enabled when the global signup disable flag is not true", () => {
+    process.env.AUTH_DISABLE_SIGNUP = "false";
+    setOidcEnv();
+    const orm = {
+      em: {},
+    } as unknown as MikroORM;
+    const authProvider = getAuthProvider();
+
+    authProvider.useFactory(
+      {
+        entities,
+        secret,
+      },
+      orm,
+    );
+
+    expect(mockBetterAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailAndPassword: expect.objectContaining({
+          disableSignUp: false,
+        }),
+      }),
+    );
+    expect(mockGenericOAuth).toHaveBeenCalledWith({
+      config: [
+        expect.objectContaining({
+          disableSignUp: false,
+          providerId: "oidc",
+        }),
+      ],
+    });
+  });
+
+  it("should skip OIDC plugin registration when OIDC env is not configured", () => {
+    const orm = {
+      em: {},
+    } as unknown as MikroORM;
+    const authProvider = getAuthProvider();
+
+    authProvider.useFactory(
+      {
+        entities,
+        secret,
+      },
+      orm,
+    );
+
+    expect(mockGenericOAuth).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["AUTH_OIDC_CLIENT_ID"],
+    ["AUTH_OIDC_CLIENT_SECRET"],
+    ["AUTH_OIDC_DISCOVERY_URL"],
+  ])("should reject missing %s when OIDC env is configured", (envName) => {
+    setOidcEnv();
+    process.env[envName] = "";
+    const orm = {
+      em: {},
+    } as unknown as MikroORM;
+    const authProvider = getAuthProvider();
+
+    expect(() =>
+      authProvider.useFactory(
+        {
+          entities,
+          secret,
+        },
+        orm,
+      ),
+    ).toThrow(envName);
+  });
+
+  it("should reject invalid OIDC prompt values", () => {
+    setOidcEnv();
+    process.env.AUTH_OIDC_PROMPT = "invalid";
+    const orm = {
+      em: {},
+    } as unknown as MikroORM;
+    const authProvider = getAuthProvider();
+
+    expect(() =>
+      authProvider.useFactory(
+        {
+          entities,
+          secret,
+        },
+        orm,
+      ),
+    ).toThrow("AUTH_OIDC_PROMPT");
+  });
+
+  it("should keep env OIDC plugin when custom plugins are configured", () => {
+    setOidcEnv();
+    const customPlugin = {
+      id: "custom-plugin",
+    };
+    const orm = {
+      em: {},
+    } as unknown as MikroORM;
+    const authProvider = getAuthProvider();
+
+    authProvider.useFactory(
+      {
+        entities,
+        plugins: [customPlugin],
+        secret,
+      },
+      orm,
+    );
+
+    expect(mockBetterAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plugins: [
+          {
+            options: {
+              config: [
+                expect.objectContaining({
+                  providerId: "oidc",
+                }),
+              ],
+            },
+            type: "generic-oauth",
+          },
+          customPlugin,
+        ],
       }),
     );
   });

--- a/packages/auth/src/auth.module.spec.ts
+++ b/packages/auth/src/auth.module.spec.ts
@@ -58,6 +58,16 @@ function setOidcEnv() {
     "https://oidc.example.com/.well-known/openid-configuration";
 }
 
+function setGoogleEnv() {
+  process.env.AUTH_GOOGLE_CLIENT_ID = "google-client-id";
+  process.env.AUTH_GOOGLE_CLIENT_SECRET = "google-client-secret";
+}
+
+function setGithubEnv() {
+  process.env.AUTH_GITHUB_CLIENT_ID = "github-client-id";
+  process.env.AUTH_GITHUB_CLIENT_SECRET = "github-client-secret";
+}
+
 function getAuthProvider() {
   const providers = Reflect.getMetadata(
     MODULE_METADATA.PROVIDERS,
@@ -142,6 +152,12 @@ describe("AuthModule", () => {
     delete process.env.AUTH_DISABLE_SIGNUP;
     delete process.env.AUTH_EMAIL_ENABLED;
     delete process.env.AUTH_EMAIL_DISABLE_SIGNUP;
+    delete process.env.AUTH_GITHUB_CLIENT_ID;
+    delete process.env.AUTH_GITHUB_CLIENT_SECRET;
+    delete process.env.AUTH_GITHUB_DISABLE_SIGNUP;
+    delete process.env.AUTH_GOOGLE_CLIENT_ID;
+    delete process.env.AUTH_GOOGLE_CLIENT_SECRET;
+    delete process.env.AUTH_GOOGLE_DISABLE_SIGNUP;
     delete process.env.AUTH_OIDC_CLIENT_ID;
     delete process.env.AUTH_OIDC_CLIENT_SECRET;
     delete process.env.AUTH_OIDC_DISCOVERY_URL;
@@ -236,6 +252,8 @@ describe("AuthModule", () => {
   it("should disable email and OIDC signup when the global signup disable flag is enabled", () => {
     process.env.AUTH_DISABLE_SIGNUP = "true";
     process.env.AUTH_EMAIL_ENABLED = "true";
+    setGithubEnv();
+    setGoogleEnv();
     setOidcEnv();
     const orm = {
       em: {},
@@ -255,6 +273,14 @@ describe("AuthModule", () => {
         emailAndPassword: expect.objectContaining({
           disableSignUp: true,
         }),
+        socialProviders: {
+          github: expect.objectContaining({
+            disableSignUp: true,
+          }),
+          google: expect.objectContaining({
+            disableSignUp: true,
+          }),
+        },
       }),
     );
     expect(mockGenericOAuth).toHaveBeenCalledWith({
@@ -266,6 +292,100 @@ describe("AuthModule", () => {
       ],
     });
   });
+
+  it("should create dedicated Google and GitHub social providers from env", () => {
+    setGithubEnv();
+    setGoogleEnv();
+    const orm = {
+      em: {},
+    } as unknown as MikroORM;
+    const authProvider = getAuthProvider();
+
+    authProvider.useFactory(
+      {
+        entities,
+        secret,
+      },
+      orm,
+    );
+
+    expect(mockBetterAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        socialProviders: {
+          github: {
+            clientId: "github-client-id",
+            clientSecret: "github-client-secret",
+            disableSignUp: false,
+          },
+          google: {
+            clientId: "google-client-id",
+            clientSecret: "google-client-secret",
+            disableSignUp: false,
+          },
+        },
+      }),
+    );
+    expect(mockGenericOAuth).not.toHaveBeenCalled();
+  });
+
+  it("should disable signup for provider-specific social provider flags", () => {
+    process.env.AUTH_GITHUB_DISABLE_SIGNUP = "true";
+    process.env.AUTH_GOOGLE_DISABLE_SIGNUP = "true";
+    setGithubEnv();
+    setGoogleEnv();
+    const orm = {
+      em: {},
+    } as unknown as MikroORM;
+    const authProvider = getAuthProvider();
+
+    authProvider.useFactory(
+      {
+        entities,
+        secret,
+      },
+      orm,
+    );
+
+    expect(mockBetterAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        socialProviders: {
+          github: expect.objectContaining({
+            disableSignUp: true,
+          }),
+          google: expect.objectContaining({
+            disableSignUp: true,
+          }),
+        },
+      }),
+    );
+  });
+
+  it.each([
+    ["AUTH_GOOGLE_CLIENT_ID", setGoogleEnv],
+    ["AUTH_GOOGLE_CLIENT_SECRET", setGoogleEnv],
+    ["AUTH_GITHUB_CLIENT_ID", setGithubEnv],
+    ["AUTH_GITHUB_CLIENT_SECRET", setGithubEnv],
+  ])(
+    "should reject missing %s when social provider env is configured",
+    (envName, setEnv) => {
+      setEnv();
+      process.env[envName] = "";
+      const orm = {
+        em: {},
+      } as unknown as MikroORM;
+      const authProvider = getAuthProvider();
+
+      expect(() =>
+        authProvider.useFactory(
+          {
+            entities,
+            secret,
+          },
+          orm,
+        ),
+      ).toThrow(envName);
+    },
+  );
 
   it("should keep signup enabled when the global signup disable flag is not true", () => {
     process.env.AUTH_DISABLE_SIGNUP = "false";
@@ -415,6 +535,50 @@ describe("AuthModule", () => {
           disableSignUp: true,
           enabled: true,
           maxPasswordLength: 128,
+        },
+      }),
+    );
+  });
+
+  it("should merge social provider options without dropping env signup disable flags", () => {
+    process.env.AUTH_DISABLE_SIGNUP = "true";
+    const orm = {
+      em: {},
+    } as unknown as MikroORM;
+    const authProvider = getAuthProvider();
+
+    authProvider.useFactory(
+      {
+        entities,
+        secret,
+        socialProviders: {
+          apple: {
+            clientId: "apple-client-id",
+            clientSecret: "apple-client-secret",
+          },
+          google: {
+            clientId: "google-client-id",
+            clientSecret: "google-client-secret",
+            scope: ["email"],
+          },
+        },
+      },
+      orm,
+    );
+
+    expect(mockBetterAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        socialProviders: {
+          apple: {
+            clientId: "apple-client-id",
+            clientSecret: "apple-client-secret",
+          },
+          google: {
+            clientId: "google-client-id",
+            clientSecret: "google-client-secret",
+            disableSignUp: true,
+            scope: ["email"],
+          },
         },
       }),
     );

--- a/packages/auth/src/auth.module.spec.ts
+++ b/packages/auth/src/auth.module.spec.ts
@@ -52,6 +52,7 @@ const entities = {
 };
 
 function setOidcEnv() {
+  process.env.AUTH_OIDC_ENABLED = "true";
   process.env.AUTH_OIDC_CLIENT_ID = "oidc-client-id";
   process.env.AUTH_OIDC_CLIENT_SECRET = "oidc-client-secret";
   process.env.AUTH_OIDC_DISCOVERY_URL =
@@ -59,11 +60,13 @@ function setOidcEnv() {
 }
 
 function setGoogleEnv() {
+  process.env.AUTH_GOOGLE_ENABLED = "true";
   process.env.AUTH_GOOGLE_CLIENT_ID = "google-client-id";
   process.env.AUTH_GOOGLE_CLIENT_SECRET = "google-client-secret";
 }
 
 function setGithubEnv() {
+  process.env.AUTH_GITHUB_ENABLED = "true";
   process.env.AUTH_GITHUB_CLIENT_ID = "github-client-id";
   process.env.AUTH_GITHUB_CLIENT_SECRET = "github-client-secret";
 }
@@ -155,13 +158,16 @@ describe("AuthModule", () => {
     delete process.env.AUTH_GITHUB_CLIENT_ID;
     delete process.env.AUTH_GITHUB_CLIENT_SECRET;
     delete process.env.AUTH_GITHUB_DISABLE_SIGNUP;
+    delete process.env.AUTH_GITHUB_ENABLED;
     delete process.env.AUTH_GOOGLE_CLIENT_ID;
     delete process.env.AUTH_GOOGLE_CLIENT_SECRET;
     delete process.env.AUTH_GOOGLE_DISABLE_SIGNUP;
+    delete process.env.AUTH_GOOGLE_ENABLED;
     delete process.env.AUTH_OIDC_CLIENT_ID;
     delete process.env.AUTH_OIDC_CLIENT_SECRET;
     delete process.env.AUTH_OIDC_DISCOVERY_URL;
     delete process.env.AUTH_OIDC_DISABLE_SIGNUP;
+    delete process.env.AUTH_OIDC_ENABLED;
     delete process.env.AUTH_OIDC_PROMPT;
     delete process.env.AUTH_OIDC_SCOPES;
     delete process.env.APP_URL;
@@ -316,11 +322,13 @@ describe("AuthModule", () => {
             clientId: "github-client-id",
             clientSecret: "github-client-secret",
             disableSignUp: false,
+            enabled: true,
           },
           google: {
             clientId: "google-client-id",
             clientSecret: "google-client-secret",
             disableSignUp: false,
+            enabled: true,
           },
         },
       }),
@@ -355,6 +363,67 @@ describe("AuthModule", () => {
           google: expect.objectContaining({
             disableSignUp: true,
           }),
+        },
+      }),
+    );
+  });
+
+  it("should apply provider-specific social provider enabled flags", () => {
+    setGoogleEnv();
+    const orm = {
+      em: {},
+    } as unknown as MikroORM;
+    const authProvider = getAuthProvider();
+
+    authProvider.useFactory(
+      {
+        entities,
+        secret,
+      },
+      orm,
+    );
+
+    expect(mockBetterAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        socialProviders: {
+          google: expect.objectContaining({
+            enabled: true,
+          }),
+        },
+      }),
+    );
+  });
+
+  it("should disable manually configured social providers when provider enabled env is false", () => {
+    process.env.AUTH_GITHUB_ENABLED = "false";
+    const orm = {
+      em: {},
+    } as unknown as MikroORM;
+    const authProvider = getAuthProvider();
+
+    authProvider.useFactory(
+      {
+        entities,
+        secret,
+        socialProviders: {
+          github: {
+            clientId: "github-client-id",
+            clientSecret: "github-client-secret",
+            enabled: true,
+          },
+        },
+      },
+      orm,
+    );
+
+    expect(mockBetterAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        socialProviders: {
+          github: {
+            clientId: "github-client-id",
+            clientSecret: "github-client-secret",
+            enabled: false,
+          },
         },
       }),
     );
@@ -414,6 +483,27 @@ describe("AuthModule", () => {
   });
 
   it("should skip OIDC plugin registration when OIDC env is not configured", () => {
+    const orm = {
+      em: {},
+    } as unknown as MikroORM;
+    const authProvider = getAuthProvider();
+
+    authProvider.useFactory(
+      {
+        entities,
+        secret,
+      },
+      orm,
+    );
+
+    expect(mockGenericOAuth).not.toHaveBeenCalled();
+  });
+
+  it("should skip OIDC plugin registration when OIDC credentials are configured but AUTH_OIDC_ENABLED is unset", () => {
+    process.env.AUTH_OIDC_CLIENT_ID = "oidc-client-id";
+    process.env.AUTH_OIDC_CLIENT_SECRET = "oidc-client-secret";
+    process.env.AUTH_OIDC_DISCOVERY_URL =
+      "https://oidc.example.com/.well-known/openid-configuration";
     const orm = {
       em: {},
     } as unknown as MikroORM;
@@ -508,6 +598,29 @@ describe("AuthModule", () => {
         ],
       }),
     );
+  });
+
+  it("should reject env OIDC when a custom genericOAuth plugin is configured", () => {
+    setOidcEnv();
+    const orm = {
+      em: {},
+    } as unknown as MikroORM;
+    const authProvider = getAuthProvider();
+
+    expect(() =>
+      authProvider.useFactory(
+        {
+          entities,
+          plugins: [
+            {
+              id: "generic-oauth",
+            },
+          ],
+          secret,
+        },
+        orm,
+      ),
+    ).toThrow("AUTH_OIDC_*");
   });
 
   it("should merge email auth options without dropping env signup disable flags", () => {

--- a/packages/auth/src/auth.module.spec.ts
+++ b/packages/auth/src/auth.module.spec.ts
@@ -235,6 +235,7 @@ describe("AuthModule", () => {
 
   it("should disable email and OIDC signup when the global signup disable flag is enabled", () => {
     process.env.AUTH_DISABLE_SIGNUP = "true";
+    process.env.AUTH_EMAIL_ENABLED = "true";
     setOidcEnv();
     const orm = {
       em: {},
@@ -282,13 +283,6 @@ describe("AuthModule", () => {
       orm,
     );
 
-    expect(mockBetterAuth).toHaveBeenCalledWith(
-      expect.objectContaining({
-        emailAndPassword: expect.objectContaining({
-          disableSignUp: false,
-        }),
-      }),
-    );
     expect(mockGenericOAuth).toHaveBeenCalledWith({
       config: [
         expect.objectContaining({
@@ -392,6 +386,36 @@ describe("AuthModule", () => {
           },
           customPlugin,
         ],
+      }),
+    );
+  });
+
+  it("should merge email auth options without dropping env signup disable flags", () => {
+    process.env.AUTH_DISABLE_SIGNUP = "true";
+    const orm = {
+      em: {},
+    } as unknown as MikroORM;
+    const authProvider = getAuthProvider();
+
+    authProvider.useFactory(
+      {
+        emailAndPassword: {
+          enabled: true,
+          maxPasswordLength: 128,
+        },
+        entities,
+        secret,
+      },
+      orm,
+    );
+
+    expect(mockBetterAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailAndPassword: {
+          disableSignUp: true,
+          enabled: true,
+          maxPasswordLength: 128,
+        },
       }),
     );
   });

--- a/packages/auth/src/auth.module.ts
+++ b/packages/auth/src/auth.module.ts
@@ -22,6 +22,7 @@ import { AuthService } from "./auth.service";
 import { AuthModuleOptions } from "./auth-module-options.interface";
 import { createEmailAndPasswordConfig } from "./utils/create-email-and-password-config";
 import { createOidcConfig } from "./utils/create-oidc-config";
+import { createSocialProvidersConfig } from "./utils/create-social-providers-config";
 import { isEnvTrue } from "./utils/is-env-true";
 import { resolveSecret } from "./utils/resolve-secret";
 
@@ -45,10 +46,19 @@ import { resolveSecret } from "./utils/resolve-secret";
         const secret = resolveSecret(options);
         const disableSignUp = isEnvTrue("AUTH_DISABLE_SIGNUP");
         const oidcConfig = createOidcConfig(disableSignUp);
-        const { emailAndPassword, plugins, ...betterAuthOptions } = options;
+        const {
+          emailAndPassword,
+          plugins,
+          socialProviders,
+          ...betterAuthOptions
+        } = options;
         const emailAndPasswordConfig = createEmailAndPasswordConfig(
           disableSignUp,
           emailAndPassword,
+        );
+        const socialProvidersConfig = createSocialProvidersConfig(
+          disableSignUp,
+          socialProviders,
         );
 
         return betterAuth({
@@ -61,6 +71,9 @@ import { resolveSecret } from "./utils/resolve-secret";
           ...betterAuthOptions,
           ...(emailAndPasswordConfig
             ? { emailAndPassword: emailAndPasswordConfig }
+            : {}),
+          ...(socialProvidersConfig
+            ? { socialProviders: socialProvidersConfig }
             : {}),
           plugins: [
             ...(oidcConfig

--- a/packages/auth/src/auth.module.ts
+++ b/packages/auth/src/auth.module.ts
@@ -20,6 +20,7 @@ import {
 } from "./auth.module-definition";
 import { AuthService } from "./auth.service";
 import { AuthModuleOptions } from "./auth-module-options.interface";
+import { assertNoDuplicateGenericOAuthPlugin } from "./utils/assert-no-duplicate-generic-oauth-plugin";
 import { createEmailAndPasswordConfig } from "./utils/create-email-and-password-config";
 import { createOidcConfig } from "./utils/create-oidc-config";
 import { createSocialProvidersConfig } from "./utils/create-social-providers-config";
@@ -60,6 +61,10 @@ import { resolveSecret } from "./utils/resolve-secret";
           disableSignUp,
           socialProviders,
         );
+
+        if (oidcConfig) {
+          assertNoDuplicateGenericOAuthPlugin(plugins);
+        }
 
         return betterAuth({
           appName: process.env.APP_NAME,

--- a/packages/auth/src/auth.module.ts
+++ b/packages/auth/src/auth.module.ts
@@ -45,7 +45,11 @@ import { resolveSecret } from "./utils/resolve-secret";
         const secret = resolveSecret(options);
         const disableSignUp = isEnvTrue("AUTH_DISABLE_SIGNUP");
         const oidcConfig = createOidcConfig(disableSignUp);
-        const { plugins, ...betterAuthOptions } = options;
+        const { emailAndPassword, plugins, ...betterAuthOptions } = options;
+        const emailAndPasswordConfig = createEmailAndPasswordConfig(
+          disableSignUp,
+          emailAndPassword,
+        );
 
         return betterAuth({
           appName: process.env.APP_NAME,
@@ -54,8 +58,10 @@ import { resolveSecret } from "./utils/resolve-secret";
           account: {
             skipStateCookieCheck: true,
           },
-          emailAndPassword: createEmailAndPasswordConfig(disableSignUp),
           ...betterAuthOptions,
+          ...(emailAndPasswordConfig
+            ? { emailAndPassword: emailAndPasswordConfig }
+            : {}),
           plugins: [
             ...(oidcConfig
               ? [

--- a/packages/auth/src/auth.module.ts
+++ b/packages/auth/src/auth.module.ts
@@ -7,6 +7,7 @@ import {
 import { type DynamicModule, Global, Inject, Module } from "@nestjs/common";
 import { type Auth, betterAuth } from "better-auth";
 import { toNodeHandler } from "better-auth/node";
+import { genericOAuth } from "better-auth/plugins";
 
 import { mikroOrmAdapter } from "./adapters/mikro-orm-adapter";
 import { AUTH_TOKEN } from "./auth.constants";
@@ -19,7 +20,10 @@ import {
 } from "./auth.module-definition";
 import { AuthService } from "./auth.service";
 import { AuthModuleOptions } from "./auth-module-options.interface";
-import { estimateEntropy } from "./utils/estimate-entropy";
+import { createEmailAndPasswordConfig } from "./utils/create-email-and-password-config";
+import { createOidcConfig } from "./utils/create-oidc-config";
+import { isEnvTrue } from "./utils/is-env-true";
+import { resolveSecret } from "./utils/resolve-secret";
 
 /**
  * Authentication module based on better-auth.
@@ -38,43 +42,30 @@ import { estimateEntropy } from "./utils/estimate-entropy";
       provide: AUTH_TOKEN,
       inject: [MODULE_OPTIONS_TOKEN, MikroORM],
       useFactory: (options: AuthModuleOptions, orm: MikroORM) => {
-        const secret =
-          options.secret ?? process.env.AUTH_SECRET ?? process.env.APP_SECRET;
-
-        if (!secret) {
-          throw new Error(
-            "Auth secret is required.\n" +
-              "Set AUTH_SECRET or APP_SECRET environment variable, or pass a secret option.\n" +
-              "Generate a secure secret with:\n" +
-              "  node -e \"console.log(require('crypto').randomBytes(32).toString('base64url'))\"",
-          );
-        }
-
-        if (secret.length < 32) {
-          throw new Error(
-            "Auth secret must be at least 32 characters long.\n" +
-              "Set AUTH_SECRET or APP_SECRET environment variable, or pass a secret option.\n" +
-              "Generate a secure secret with:\n" +
-              "  node -e \"console.log(require('crypto').randomBytes(32).toString('base64url'))\"",
-          );
-        }
-
-        if (estimateEntropy(secret) < 120) {
-          throw new Error(
-            "Auth secret appears low-entropy.\n" +
-              "Use a randomly generated secret for production.\n" +
-              "Generate a secure secret with:\n" +
-              "  node -e \"console.log(require('crypto').randomBytes(32).toString('base64url'))\"",
-          );
-        }
+        const secret = resolveSecret(options);
+        const disableSignUp = isEnvTrue("AUTH_DISABLE_SIGNUP");
+        const oidcConfig = createOidcConfig(disableSignUp);
+        const { plugins, ...betterAuthOptions } = options;
 
         return betterAuth({
+          appName: process.env.APP_NAME,
           baseURL: process.env.AUTH_URL ?? process.env.APP_URL,
           secret,
           account: {
             skipStateCookieCheck: true,
           },
-          ...options,
+          emailAndPassword: createEmailAndPasswordConfig(disableSignUp),
+          ...betterAuthOptions,
+          plugins: [
+            ...(oidcConfig
+              ? [
+                  genericOAuth({
+                    config: [oidcConfig],
+                  }),
+                ]
+              : []),
+            ...(plugins ?? []),
+          ],
           database: mikroOrmAdapter({
             orm,
             entities: options.entities,

--- a/packages/auth/src/index.spec.ts
+++ b/packages/auth/src/index.spec.ts
@@ -4,6 +4,9 @@ jest.mock("better-auth", () => ({
 jest.mock("better-auth/node", () => ({
   toNodeHandler: jest.fn(),
 }));
+jest.mock("better-auth/plugins", () => ({
+  genericOAuth: jest.fn(),
+}));
 jest.mock("./adapters/mikro-orm-adapter", () => ({
   mikroOrmAdapter: jest.fn(),
 }));

--- a/packages/auth/src/utils/assert-no-duplicate-generic-oauth-plugin.spec.ts
+++ b/packages/auth/src/utils/assert-no-duplicate-generic-oauth-plugin.spec.ts
@@ -1,0 +1,29 @@
+import { assertNoDuplicateGenericOAuthPlugin } from "./assert-no-duplicate-generic-oauth-plugin";
+
+describe("assertNoDuplicateGenericOAuthPlugin", () => {
+  it("should allow undefined plugins", () => {
+    expect(() => {
+      assertNoDuplicateGenericOAuthPlugin();
+    }).not.toThrow();
+  });
+
+  it("should allow non-generic-oauth plugins", () => {
+    expect(() => {
+      assertNoDuplicateGenericOAuthPlugin([
+        {
+          id: "custom-plugin",
+        },
+      ]);
+    }).not.toThrow();
+  });
+
+  it("should reject manually configured genericOAuth plugins", () => {
+    expect(() => {
+      assertNoDuplicateGenericOAuthPlugin([
+        {
+          id: "generic-oauth",
+        },
+      ]);
+    }).toThrow("AUTH_OIDC_*");
+  });
+});

--- a/packages/auth/src/utils/assert-no-duplicate-generic-oauth-plugin.ts
+++ b/packages/auth/src/utils/assert-no-duplicate-generic-oauth-plugin.ts
@@ -1,0 +1,14 @@
+import { BetterAuthPlugin } from "better-auth";
+
+export function assertNoDuplicateGenericOAuthPlugin(
+  plugins?: BetterAuthPlugin[],
+): void {
+  if (!plugins?.some((plugin) => plugin.id === "generic-oauth")) {
+    return;
+  }
+
+  throw new Error(
+    "AUTH_OIDC_* cannot be used together with a manually configured genericOAuth plugin.\n" +
+      "Configure all generic OAuth providers in plugins, or remove the custom genericOAuth plugin and use AUTH_OIDC_* only.",
+  );
+}

--- a/packages/auth/src/utils/create-email-and-password-config.spec.ts
+++ b/packages/auth/src/utils/create-email-and-password-config.spec.ts
@@ -1,0 +1,40 @@
+import { createEmailAndPasswordConfig } from "./create-email-and-password-config";
+
+describe("createEmailAndPasswordConfig", () => {
+  beforeEach(() => {
+    delete process.env.AUTH_EMAIL_DISABLE_SIGNUP;
+    delete process.env.AUTH_EMAIL_ENABLED;
+  });
+
+  it("should enable email auth and signup by default", () => {
+    expect(createEmailAndPasswordConfig(false)).toEqual({
+      disableSignUp: false,
+      enabled: true,
+    });
+  });
+
+  it("should disable email auth when AUTH_EMAIL_ENABLED is false", () => {
+    process.env.AUTH_EMAIL_ENABLED = "false";
+
+    expect(createEmailAndPasswordConfig(false)).toEqual({
+      disableSignUp: false,
+      enabled: false,
+    });
+  });
+
+  it("should disable signup when the global disable flag is true", () => {
+    expect(createEmailAndPasswordConfig(true)).toEqual({
+      disableSignUp: true,
+      enabled: true,
+    });
+  });
+
+  it("should disable signup when AUTH_EMAIL_DISABLE_SIGNUP is true", () => {
+    process.env.AUTH_EMAIL_DISABLE_SIGNUP = "true";
+
+    expect(createEmailAndPasswordConfig(false)).toEqual({
+      disableSignUp: true,
+      enabled: true,
+    });
+  });
+});

--- a/packages/auth/src/utils/create-email-and-password-config.spec.ts
+++ b/packages/auth/src/utils/create-email-and-password-config.spec.ts
@@ -6,7 +6,13 @@ describe("createEmailAndPasswordConfig", () => {
     delete process.env.AUTH_EMAIL_ENABLED;
   });
 
-  it("should enable email auth and signup by default", () => {
+  it("should preserve better-auth defaults when email auth is not configured", () => {
+    expect(createEmailAndPasswordConfig(false)).toBeUndefined();
+  });
+
+  it("should enable email auth when AUTH_EMAIL_ENABLED is true", () => {
+    process.env.AUTH_EMAIL_ENABLED = "true";
+
     expect(createEmailAndPasswordConfig(false)).toEqual({
       disableSignUp: false,
       enabled: true,
@@ -22,17 +28,53 @@ describe("createEmailAndPasswordConfig", () => {
     });
   });
 
-  it("should disable signup when the global disable flag is true", () => {
+  it("should not create email auth config for signup disable flags alone", () => {
+    process.env.AUTH_EMAIL_DISABLE_SIGNUP = "true";
+
+    expect(createEmailAndPasswordConfig(true)).toBeUndefined();
+  });
+
+  it("should disable signup when the global disable flag is true and email auth is configured", () => {
+    process.env.AUTH_EMAIL_ENABLED = "true";
+
     expect(createEmailAndPasswordConfig(true)).toEqual({
       disableSignUp: true,
       enabled: true,
     });
   });
 
-  it("should disable signup when AUTH_EMAIL_DISABLE_SIGNUP is true", () => {
+  it("should disable signup when AUTH_EMAIL_DISABLE_SIGNUP is true and email auth is configured", () => {
+    process.env.AUTH_EMAIL_ENABLED = "true";
     process.env.AUTH_EMAIL_DISABLE_SIGNUP = "true";
 
     expect(createEmailAndPasswordConfig(false)).toEqual({
+      disableSignUp: true,
+      enabled: true,
+    });
+  });
+
+  it("should merge with explicit email auth options", () => {
+    process.env.AUTH_EMAIL_DISABLE_SIGNUP = "true";
+
+    expect(
+      createEmailAndPasswordConfig(false, {
+        enabled: true,
+        maxPasswordLength: 128,
+      }),
+    ).toEqual({
+      disableSignUp: true,
+      enabled: true,
+      maxPasswordLength: 128,
+    });
+  });
+
+  it("should preserve explicit signup disable from email auth options", () => {
+    expect(
+      createEmailAndPasswordConfig(false, {
+        disableSignUp: true,
+        enabled: true,
+      }),
+    ).toEqual({
       disableSignUp: true,
       enabled: true,
     });

--- a/packages/auth/src/utils/create-email-and-password-config.ts
+++ b/packages/auth/src/utils/create-email-and-password-config.ts
@@ -1,0 +1,8 @@
+import { isEnvTrue } from "./is-env-true";
+
+export function createEmailAndPasswordConfig(disableSignUp: boolean) {
+  return {
+    enabled: process.env.AUTH_EMAIL_ENABLED !== "false",
+    disableSignUp: disableSignUp || isEnvTrue("AUTH_EMAIL_DISABLE_SIGNUP"),
+  };
+}

--- a/packages/auth/src/utils/create-email-and-password-config.ts
+++ b/packages/auth/src/utils/create-email-and-password-config.ts
@@ -1,8 +1,29 @@
+import { AuthModuleOptions } from "../auth-module-options.interface";
 import { isEnvTrue } from "./is-env-true";
 
-export function createEmailAndPasswordConfig(disableSignUp: boolean) {
+type EmailAndPasswordConfig = NonNullable<
+  AuthModuleOptions["emailAndPassword"]
+>;
+
+export function createEmailAndPasswordConfig(
+  disableSignUp: boolean,
+  options?: EmailAndPasswordConfig,
+): EmailAndPasswordConfig | undefined {
+  const hasEnabledEnv = process.env.AUTH_EMAIL_ENABLED !== undefined;
+  const shouldDisableSignUp =
+    disableSignUp || isEnvTrue("AUTH_EMAIL_DISABLE_SIGNUP");
+
+  if (!options && !hasEnabledEnv) {
+    return undefined;
+  }
+
   return {
-    enabled: process.env.AUTH_EMAIL_ENABLED !== "false",
-    disableSignUp: disableSignUp || isEnvTrue("AUTH_EMAIL_DISABLE_SIGNUP"),
+    ...(options ?? {
+      enabled: process.env.AUTH_EMAIL_ENABLED !== "false",
+    }),
+    ...(hasEnabledEnv
+      ? { enabled: process.env.AUTH_EMAIL_ENABLED !== "false" }
+      : {}),
+    disableSignUp: shouldDisableSignUp || options?.disableSignUp === true,
   };
 }

--- a/packages/auth/src/utils/create-oidc-config.spec.ts
+++ b/packages/auth/src/utils/create-oidc-config.spec.ts
@@ -6,6 +6,7 @@ describe("createOidcConfig", () => {
     delete process.env.AUTH_OIDC_CLIENT_SECRET;
     delete process.env.AUTH_OIDC_DISCOVERY_URL;
     delete process.env.AUTH_OIDC_DISABLE_SIGNUP;
+    delete process.env.AUTH_OIDC_ENABLED;
     delete process.env.AUTH_OIDC_PROMPT;
     delete process.env.AUTH_OIDC_SCOPES;
   });
@@ -14,13 +15,33 @@ describe("createOidcConfig", () => {
     expect(createOidcConfig(false)).toBeUndefined();
   });
 
+  it("should return undefined when OIDC credentials are configured but AUTH_OIDC_ENABLED is unset", () => {
+    process.env.AUTH_OIDC_CLIENT_ID = "client-id";
+    process.env.AUTH_OIDC_CLIENT_SECRET = "client-secret";
+    process.env.AUTH_OIDC_DISCOVERY_URL =
+      "https://oidc.example.com/.well-known/openid-configuration";
+
+    expect(createOidcConfig(false)).toBeUndefined();
+  });
+
+  it("should return undefined when AUTH_OIDC_ENABLED is false", () => {
+    process.env.AUTH_OIDC_ENABLED = "false";
+    process.env.AUTH_OIDC_CLIENT_ID = "client-id";
+    process.env.AUTH_OIDC_CLIENT_SECRET = "client-secret";
+    process.env.AUTH_OIDC_DISCOVERY_URL =
+      "https://oidc.example.com/.well-known/openid-configuration";
+
+    expect(createOidcConfig(false)).toBeUndefined();
+  });
+
   it("should create OIDC config from env", () => {
+    process.env.AUTH_OIDC_ENABLED = "true";
     process.env.AUTH_OIDC_CLIENT_ID = "client-id";
     process.env.AUTH_OIDC_CLIENT_SECRET = "client-secret";
     process.env.AUTH_OIDC_DISCOVERY_URL =
       "https://oidc.example.com/.well-known/openid-configuration";
     process.env.AUTH_OIDC_PROMPT = "login";
-    process.env.AUTH_OIDC_SCOPES = "openid,email";
+    process.env.AUTH_OIDC_SCOPES = "openid, email,";
 
     expect(createOidcConfig(false)).toEqual({
       clientId: "client-id",
@@ -34,6 +55,7 @@ describe("createOidcConfig", () => {
   });
 
   it("should use default scopes and global signup disable", () => {
+    process.env.AUTH_OIDC_ENABLED = "true";
     process.env.AUTH_OIDC_CLIENT_ID = "client-id";
     process.env.AUTH_OIDC_CLIENT_SECRET = "client-secret";
     process.env.AUTH_OIDC_DISCOVERY_URL =
@@ -48,6 +70,7 @@ describe("createOidcConfig", () => {
   });
 
   it("should disable signup when AUTH_OIDC_DISABLE_SIGNUP is true", () => {
+    process.env.AUTH_OIDC_ENABLED = "true";
     process.env.AUTH_OIDC_CLIENT_ID = "client-id";
     process.env.AUTH_OIDC_CLIENT_SECRET = "client-secret";
     process.env.AUTH_OIDC_DISCOVERY_URL =

--- a/packages/auth/src/utils/create-oidc-config.spec.ts
+++ b/packages/auth/src/utils/create-oidc-config.spec.ts
@@ -1,0 +1,63 @@
+import { createOidcConfig } from "./create-oidc-config";
+
+describe("createOidcConfig", () => {
+  beforeEach(() => {
+    delete process.env.AUTH_OIDC_CLIENT_ID;
+    delete process.env.AUTH_OIDC_CLIENT_SECRET;
+    delete process.env.AUTH_OIDC_DISCOVERY_URL;
+    delete process.env.AUTH_OIDC_DISABLE_SIGNUP;
+    delete process.env.AUTH_OIDC_PROMPT;
+    delete process.env.AUTH_OIDC_SCOPES;
+  });
+
+  it("should return undefined when OIDC env is not configured", () => {
+    expect(createOidcConfig(false)).toBeUndefined();
+  });
+
+  it("should create OIDC config from env", () => {
+    process.env.AUTH_OIDC_CLIENT_ID = "client-id";
+    process.env.AUTH_OIDC_CLIENT_SECRET = "client-secret";
+    process.env.AUTH_OIDC_DISCOVERY_URL =
+      "https://oidc.example.com/.well-known/openid-configuration";
+    process.env.AUTH_OIDC_PROMPT = "login";
+    process.env.AUTH_OIDC_SCOPES = "openid,email";
+
+    expect(createOidcConfig(false)).toEqual({
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      disableSignUp: false,
+      discoveryUrl: "https://oidc.example.com/.well-known/openid-configuration",
+      prompt: "login",
+      providerId: "oidc",
+      scopes: ["openid", "email"],
+    });
+  });
+
+  it("should use default scopes and global signup disable", () => {
+    process.env.AUTH_OIDC_CLIENT_ID = "client-id";
+    process.env.AUTH_OIDC_CLIENT_SECRET = "client-secret";
+    process.env.AUTH_OIDC_DISCOVERY_URL =
+      "https://oidc.example.com/.well-known/openid-configuration";
+
+    expect(createOidcConfig(true)).toEqual(
+      expect.objectContaining({
+        disableSignUp: true,
+        scopes: ["openid", "profile", "email"],
+      }),
+    );
+  });
+
+  it("should disable signup when AUTH_OIDC_DISABLE_SIGNUP is true", () => {
+    process.env.AUTH_OIDC_CLIENT_ID = "client-id";
+    process.env.AUTH_OIDC_CLIENT_SECRET = "client-secret";
+    process.env.AUTH_OIDC_DISCOVERY_URL =
+      "https://oidc.example.com/.well-known/openid-configuration";
+    process.env.AUTH_OIDC_DISABLE_SIGNUP = "true";
+
+    expect(createOidcConfig(false)).toEqual(
+      expect.objectContaining({
+        disableSignUp: true,
+      }),
+    );
+  });
+});

--- a/packages/auth/src/utils/create-oidc-config.ts
+++ b/packages/auth/src/utils/create-oidc-config.ts
@@ -1,0 +1,23 @@
+import { GenericOAuthProviderConfig } from "./generic-oauth-provider-config.type";
+import { hasOidcEnvConfig } from "./has-oidc-env-config";
+import { isEnvTrue } from "./is-env-true";
+import { resolveOidcPrompt } from "./resolve-oidc-prompt";
+import { resolveRequiredOidcEnv } from "./resolve-required-oidc-env";
+
+export function createOidcConfig(
+  disableSignUp: boolean,
+): GenericOAuthProviderConfig | undefined {
+  if (!hasOidcEnvConfig()) {
+    return undefined;
+  }
+
+  return {
+    providerId: "oidc",
+    clientId: resolveRequiredOidcEnv("AUTH_OIDC_CLIENT_ID"),
+    clientSecret: resolveRequiredOidcEnv("AUTH_OIDC_CLIENT_SECRET"),
+    discoveryUrl: resolveRequiredOidcEnv("AUTH_OIDC_DISCOVERY_URL"),
+    prompt: resolveOidcPrompt(),
+    scopes: (process.env.AUTH_OIDC_SCOPES ?? "openid,profile,email").split(","),
+    disableSignUp: disableSignUp || isEnvTrue("AUTH_OIDC_DISABLE_SIGNUP"),
+  };
+}

--- a/packages/auth/src/utils/create-oidc-config.ts
+++ b/packages/auth/src/utils/create-oidc-config.ts
@@ -1,13 +1,13 @@
 import { GenericOAuthProviderConfig } from "./generic-oauth-provider-config.type";
-import { hasOidcEnvConfig } from "./has-oidc-env-config";
 import { isEnvTrue } from "./is-env-true";
 import { resolveOidcPrompt } from "./resolve-oidc-prompt";
+import { resolveOidcScopes } from "./resolve-oidc-scopes";
 import { resolveRequiredOidcEnv } from "./resolve-required-oidc-env";
 
 export function createOidcConfig(
   disableSignUp: boolean,
 ): GenericOAuthProviderConfig | undefined {
-  if (!hasOidcEnvConfig()) {
+  if (!isEnvTrue("AUTH_OIDC_ENABLED")) {
     return undefined;
   }
 
@@ -17,7 +17,7 @@ export function createOidcConfig(
     clientSecret: resolveRequiredOidcEnv("AUTH_OIDC_CLIENT_SECRET"),
     discoveryUrl: resolveRequiredOidcEnv("AUTH_OIDC_DISCOVERY_URL"),
     prompt: resolveOidcPrompt(),
-    scopes: (process.env.AUTH_OIDC_SCOPES ?? "openid,profile,email").split(","),
+    scopes: resolveOidcScopes(),
     disableSignUp: disableSignUp || isEnvTrue("AUTH_OIDC_DISABLE_SIGNUP"),
   };
 }

--- a/packages/auth/src/utils/create-social-provider-config.spec.ts
+++ b/packages/auth/src/utils/create-social-provider-config.spec.ts
@@ -5,16 +5,32 @@ describe("createSocialProviderConfig", () => {
     delete process.env.AUTH_GITHUB_CLIENT_ID;
     delete process.env.AUTH_GITHUB_CLIENT_SECRET;
     delete process.env.AUTH_GITHUB_DISABLE_SIGNUP;
+    delete process.env.AUTH_GITHUB_ENABLED;
     delete process.env.AUTH_GOOGLE_CLIENT_ID;
     delete process.env.AUTH_GOOGLE_CLIENT_SECRET;
     delete process.env.AUTH_GOOGLE_DISABLE_SIGNUP;
+    delete process.env.AUTH_GOOGLE_ENABLED;
   });
 
   it("should return undefined when provider env and options are not configured", () => {
     expect(createSocialProviderConfig("google", false)).toBeUndefined();
   });
 
+  it("should return undefined when only provider signup disable env is configured", () => {
+    process.env.AUTH_GOOGLE_DISABLE_SIGNUP = "true";
+
+    expect(createSocialProviderConfig("google", false)).toBeUndefined();
+  });
+
+  it("should return undefined when provider credentials are configured but enabled env is unset", () => {
+    process.env.AUTH_GOOGLE_CLIENT_ID = "google-client-id";
+    process.env.AUTH_GOOGLE_CLIENT_SECRET = "google-client-secret";
+
+    expect(createSocialProviderConfig("google", false)).toBeUndefined();
+  });
+
   it("should create Google config from env", () => {
+    process.env.AUTH_GOOGLE_ENABLED = "true";
     process.env.AUTH_GOOGLE_CLIENT_ID = "google-client-id";
     process.env.AUTH_GOOGLE_CLIENT_SECRET = "google-client-secret";
 
@@ -22,10 +38,81 @@ describe("createSocialProviderConfig", () => {
       clientId: "google-client-id",
       clientSecret: "google-client-secret",
       disableSignUp: false,
+      enabled: true,
     });
   });
 
+  it("should enable provider when provider enabled env is true", () => {
+    process.env.AUTH_GOOGLE_CLIENT_ID = "google-client-id";
+    process.env.AUTH_GOOGLE_CLIENT_SECRET = "google-client-secret";
+    process.env.AUTH_GOOGLE_ENABLED = "true";
+
+    expect(createSocialProviderConfig("google", false)).toEqual({
+      clientId: "google-client-id",
+      clientSecret: "google-client-secret",
+      disableSignUp: false,
+      enabled: true,
+    });
+  });
+
+  it("should disable provider when provider enabled env is false", () => {
+    process.env.AUTH_GOOGLE_ENABLED = "false";
+
+    expect(
+      createSocialProviderConfig("google", false, {
+        clientId: "option-client-id",
+        clientSecret: "option-client-secret",
+        enabled: true,
+      }),
+    ).toEqual({
+      clientId: "option-client-id",
+      clientSecret: "option-client-secret",
+      enabled: false,
+    });
+  });
+
+  it("should not override option credentials when provider enabled env is unset", () => {
+    process.env.AUTH_GOOGLE_CLIENT_ID = "env-client-id";
+    process.env.AUTH_GOOGLE_CLIENT_SECRET = "env-client-secret";
+
+    expect(
+      createSocialProviderConfig("google", false, {
+        clientId: "option-client-id",
+        clientSecret: "option-client-secret",
+      }),
+    ).toEqual({
+      clientId: "option-client-id",
+      clientSecret: "option-client-secret",
+    });
+  });
+
+  it("should not override option credentials when provider enabled env is false", () => {
+    process.env.AUTH_GOOGLE_ENABLED = "false";
+    process.env.AUTH_GOOGLE_CLIENT_ID = "env-client-id";
+    process.env.AUTH_GOOGLE_CLIENT_SECRET = "env-client-secret";
+
+    expect(
+      createSocialProviderConfig("google", false, {
+        clientId: "option-client-id",
+        clientSecret: "option-client-secret",
+      }),
+    ).toEqual({
+      clientId: "option-client-id",
+      clientSecret: "option-client-secret",
+      enabled: false,
+    });
+  });
+
+  it("should reject enabled provider env without credentials or options", () => {
+    process.env.AUTH_GOOGLE_ENABLED = "true";
+
+    expect(() => createSocialProviderConfig("google", false)).toThrow(
+      "AUTH_GOOGLE_CLIENT_ID",
+    );
+  });
+
   it("should create GitHub config from env", () => {
+    process.env.AUTH_GITHUB_ENABLED = "true";
     process.env.AUTH_GITHUB_CLIENT_ID = "github-client-id";
     process.env.AUTH_GITHUB_CLIENT_SECRET = "github-client-secret";
     process.env.AUTH_GITHUB_DISABLE_SIGNUP = "true";
@@ -34,6 +121,7 @@ describe("createSocialProviderConfig", () => {
       clientId: "github-client-id",
       clientSecret: "github-client-secret",
       disableSignUp: true,
+      enabled: true,
     });
   });
 
@@ -68,6 +156,7 @@ describe("createSocialProviderConfig", () => {
   });
 
   it("should prefer provider env credentials over option credentials", () => {
+    process.env.AUTH_GOOGLE_ENABLED = "true";
     process.env.AUTH_GOOGLE_CLIENT_ID = "env-client-id";
     process.env.AUTH_GOOGLE_CLIENT_SECRET = "env-client-secret";
 
@@ -80,6 +169,7 @@ describe("createSocialProviderConfig", () => {
       clientId: "env-client-id",
       clientSecret: "env-client-secret",
       disableSignUp: false,
+      enabled: true,
     });
   });
 });

--- a/packages/auth/src/utils/create-social-provider-config.spec.ts
+++ b/packages/auth/src/utils/create-social-provider-config.spec.ts
@@ -1,0 +1,85 @@
+import { createSocialProviderConfig } from "./create-social-provider-config";
+
+describe("createSocialProviderConfig", () => {
+  beforeEach(() => {
+    delete process.env.AUTH_GITHUB_CLIENT_ID;
+    delete process.env.AUTH_GITHUB_CLIENT_SECRET;
+    delete process.env.AUTH_GITHUB_DISABLE_SIGNUP;
+    delete process.env.AUTH_GOOGLE_CLIENT_ID;
+    delete process.env.AUTH_GOOGLE_CLIENT_SECRET;
+    delete process.env.AUTH_GOOGLE_DISABLE_SIGNUP;
+  });
+
+  it("should return undefined when provider env and options are not configured", () => {
+    expect(createSocialProviderConfig("google", false)).toBeUndefined();
+  });
+
+  it("should create Google config from env", () => {
+    process.env.AUTH_GOOGLE_CLIENT_ID = "google-client-id";
+    process.env.AUTH_GOOGLE_CLIENT_SECRET = "google-client-secret";
+
+    expect(createSocialProviderConfig("google", false)).toEqual({
+      clientId: "google-client-id",
+      clientSecret: "google-client-secret",
+      disableSignUp: false,
+    });
+  });
+
+  it("should create GitHub config from env", () => {
+    process.env.AUTH_GITHUB_CLIENT_ID = "github-client-id";
+    process.env.AUTH_GITHUB_CLIENT_SECRET = "github-client-secret";
+    process.env.AUTH_GITHUB_DISABLE_SIGNUP = "true";
+
+    expect(createSocialProviderConfig("github", false)).toEqual({
+      clientId: "github-client-id",
+      clientSecret: "github-client-secret",
+      disableSignUp: true,
+    });
+  });
+
+  it("should merge options without dropping signup disable flags", () => {
+    expect(
+      createSocialProviderConfig("google", true, {
+        clientId: "option-client-id",
+        clientSecret: "option-client-secret",
+        scope: ["email"],
+      }),
+    ).toEqual({
+      clientId: "option-client-id",
+      clientSecret: "option-client-secret",
+      disableSignUp: true,
+      scope: ["email"],
+    });
+  });
+
+  it("should apply provider signup disable env without requiring env credentials when options are configured", () => {
+    process.env.AUTH_GOOGLE_DISABLE_SIGNUP = "true";
+
+    expect(
+      createSocialProviderConfig("google", false, {
+        clientId: "option-client-id",
+        clientSecret: "option-client-secret",
+      }),
+    ).toEqual({
+      clientId: "option-client-id",
+      clientSecret: "option-client-secret",
+      disableSignUp: true,
+    });
+  });
+
+  it("should prefer provider env credentials over option credentials", () => {
+    process.env.AUTH_GOOGLE_CLIENT_ID = "env-client-id";
+    process.env.AUTH_GOOGLE_CLIENT_SECRET = "env-client-secret";
+
+    expect(
+      createSocialProviderConfig("google", false, {
+        clientId: "option-client-id",
+        clientSecret: "option-client-secret",
+      }),
+    ).toEqual({
+      clientId: "env-client-id",
+      clientSecret: "env-client-secret",
+      disableSignUp: false,
+    });
+  });
+});

--- a/packages/auth/src/utils/create-social-provider-config.ts
+++ b/packages/auth/src/utils/create-social-provider-config.ts
@@ -1,8 +1,8 @@
 import { AuthModuleOptions } from "../auth-module-options.interface";
 import { hasSocialProviderCredentialEnvConfig } from "./has-social-provider-credential-env-config";
-import { hasSocialProviderEnvConfig } from "./has-social-provider-env-config";
 import { isEnvTrue } from "./is-env-true";
 import { resolveRequiredSocialProviderEnv } from "./resolve-required-social-provider-env";
+import { resolveSocialProviderEnabled } from "./resolve-social-provider-enabled";
 import {
   SOCIAL_PROVIDER_ENV_CONFIGS,
   SocialProviderId,
@@ -19,22 +19,26 @@ export function createSocialProviderConfig<T extends SocialProviderId>(
   options?: SocialProviderConfig<T>,
 ): SocialProviderConfig<T> | undefined {
   const providerConfig = SOCIAL_PROVIDER_ENV_CONFIGS[provider];
-  const hasEnvConfig = hasSocialProviderEnvConfig(provider);
   const hasCredentialEnvConfig = hasSocialProviderCredentialEnvConfig(provider);
   const shouldDisableSignUp =
     disableSignUp || isEnvTrue(providerConfig.disableSignUp);
+  const hasEnabledEnv = process.env[providerConfig.enabled] !== undefined;
+  const enabled = resolveSocialProviderEnabled(provider);
+  const shouldUseCredentialEnv = enabled && hasCredentialEnvConfig;
+  const shouldCreateProvider = !!options || enabled;
 
-  if (!options && !hasEnvConfig) {
+  if (!shouldCreateProvider) {
     return undefined;
   }
 
-  if (!hasCredentialEnvConfig) {
+  if (!shouldUseCredentialEnv) {
     if (!options) {
       resolveRequiredSocialProviderEnv(provider, "clientId");
     }
 
     return {
       ...options,
+      ...(hasEnabledEnv ? { enabled } : {}),
       ...(shouldDisableSignUp || options?.disableSignUp === true
         ? { disableSignUp: true }
         : {}),
@@ -45,6 +49,7 @@ export function createSocialProviderConfig<T extends SocialProviderId>(
     ...options,
     clientId: resolveRequiredSocialProviderEnv(provider, "clientId"),
     clientSecret: resolveRequiredSocialProviderEnv(provider, "clientSecret"),
+    ...(hasEnabledEnv ? { enabled } : {}),
     disableSignUp: shouldDisableSignUp || options?.disableSignUp === true,
   } as SocialProviderConfig<T>;
 }

--- a/packages/auth/src/utils/create-social-provider-config.ts
+++ b/packages/auth/src/utils/create-social-provider-config.ts
@@ -1,0 +1,50 @@
+import { AuthModuleOptions } from "../auth-module-options.interface";
+import { hasSocialProviderCredentialEnvConfig } from "./has-social-provider-credential-env-config";
+import { hasSocialProviderEnvConfig } from "./has-social-provider-env-config";
+import { isEnvTrue } from "./is-env-true";
+import { resolveRequiredSocialProviderEnv } from "./resolve-required-social-provider-env";
+import {
+  SOCIAL_PROVIDER_ENV_CONFIGS,
+  SocialProviderId,
+} from "./social-provider.constants";
+
+type SocialProvidersConfig = NonNullable<AuthModuleOptions["socialProviders"]>;
+type SocialProviderConfig<T extends SocialProviderId> = NonNullable<
+  SocialProvidersConfig[T]
+>;
+
+export function createSocialProviderConfig<T extends SocialProviderId>(
+  provider: T,
+  disableSignUp: boolean,
+  options?: SocialProviderConfig<T>,
+): SocialProviderConfig<T> | undefined {
+  const providerConfig = SOCIAL_PROVIDER_ENV_CONFIGS[provider];
+  const hasEnvConfig = hasSocialProviderEnvConfig(provider);
+  const hasCredentialEnvConfig = hasSocialProviderCredentialEnvConfig(provider);
+  const shouldDisableSignUp =
+    disableSignUp || isEnvTrue(providerConfig.disableSignUp);
+
+  if (!options && !hasEnvConfig) {
+    return undefined;
+  }
+
+  if (!hasCredentialEnvConfig) {
+    if (!options) {
+      resolveRequiredSocialProviderEnv(provider, "clientId");
+    }
+
+    return {
+      ...options,
+      ...(shouldDisableSignUp || options?.disableSignUp === true
+        ? { disableSignUp: true }
+        : {}),
+    } as SocialProviderConfig<T>;
+  }
+
+  return {
+    ...options,
+    clientId: resolveRequiredSocialProviderEnv(provider, "clientId"),
+    clientSecret: resolveRequiredSocialProviderEnv(provider, "clientSecret"),
+    disableSignUp: shouldDisableSignUp || options?.disableSignUp === true,
+  } as SocialProviderConfig<T>;
+}

--- a/packages/auth/src/utils/create-social-providers-config.spec.ts
+++ b/packages/auth/src/utils/create-social-providers-config.spec.ts
@@ -5,9 +5,11 @@ describe("createSocialProvidersConfig", () => {
     delete process.env.AUTH_GITHUB_CLIENT_ID;
     delete process.env.AUTH_GITHUB_CLIENT_SECRET;
     delete process.env.AUTH_GITHUB_DISABLE_SIGNUP;
+    delete process.env.AUTH_GITHUB_ENABLED;
     delete process.env.AUTH_GOOGLE_CLIENT_ID;
     delete process.env.AUTH_GOOGLE_CLIENT_SECRET;
     delete process.env.AUTH_GOOGLE_DISABLE_SIGNUP;
+    delete process.env.AUTH_GOOGLE_ENABLED;
   });
 
   it("should return undefined when provider env and options are not configured", () => {
@@ -15,8 +17,10 @@ describe("createSocialProvidersConfig", () => {
   });
 
   it("should create Google and GitHub configs from env", () => {
+    process.env.AUTH_GOOGLE_ENABLED = "true";
     process.env.AUTH_GOOGLE_CLIENT_ID = "google-client-id";
     process.env.AUTH_GOOGLE_CLIENT_SECRET = "google-client-secret";
+    process.env.AUTH_GITHUB_ENABLED = "true";
     process.env.AUTH_GITHUB_CLIENT_ID = "github-client-id";
     process.env.AUTH_GITHUB_CLIENT_SECRET = "github-client-secret";
 
@@ -25,11 +29,13 @@ describe("createSocialProvidersConfig", () => {
         clientId: "github-client-id",
         clientSecret: "github-client-secret",
         disableSignUp: false,
+        enabled: true,
       },
       google: {
         clientId: "google-client-id",
         clientSecret: "google-client-secret",
         disableSignUp: false,
+        enabled: true,
       },
     });
   });

--- a/packages/auth/src/utils/create-social-providers-config.spec.ts
+++ b/packages/auth/src/utils/create-social-providers-config.spec.ts
@@ -1,0 +1,61 @@
+import { createSocialProvidersConfig } from "./create-social-providers-config";
+
+describe("createSocialProvidersConfig", () => {
+  beforeEach(() => {
+    delete process.env.AUTH_GITHUB_CLIENT_ID;
+    delete process.env.AUTH_GITHUB_CLIENT_SECRET;
+    delete process.env.AUTH_GITHUB_DISABLE_SIGNUP;
+    delete process.env.AUTH_GOOGLE_CLIENT_ID;
+    delete process.env.AUTH_GOOGLE_CLIENT_SECRET;
+    delete process.env.AUTH_GOOGLE_DISABLE_SIGNUP;
+  });
+
+  it("should return undefined when provider env and options are not configured", () => {
+    expect(createSocialProvidersConfig(false)).toBeUndefined();
+  });
+
+  it("should create Google and GitHub configs from env", () => {
+    process.env.AUTH_GOOGLE_CLIENT_ID = "google-client-id";
+    process.env.AUTH_GOOGLE_CLIENT_SECRET = "google-client-secret";
+    process.env.AUTH_GITHUB_CLIENT_ID = "github-client-id";
+    process.env.AUTH_GITHUB_CLIENT_SECRET = "github-client-secret";
+
+    expect(createSocialProvidersConfig(false)).toEqual({
+      github: {
+        clientId: "github-client-id",
+        clientSecret: "github-client-secret",
+        disableSignUp: false,
+      },
+      google: {
+        clientId: "google-client-id",
+        clientSecret: "google-client-secret",
+        disableSignUp: false,
+      },
+    });
+  });
+
+  it("should preserve custom providers from options", () => {
+    expect(
+      createSocialProvidersConfig(true, {
+        apple: {
+          clientId: "apple-client-id",
+          clientSecret: "apple-client-secret",
+        },
+        google: {
+          clientId: "google-client-id",
+          clientSecret: "google-client-secret",
+        },
+      }),
+    ).toEqual({
+      apple: {
+        clientId: "apple-client-id",
+        clientSecret: "apple-client-secret",
+      },
+      google: {
+        clientId: "google-client-id",
+        clientSecret: "google-client-secret",
+        disableSignUp: true,
+      },
+    });
+  });
+});

--- a/packages/auth/src/utils/create-social-providers-config.ts
+++ b/packages/auth/src/utils/create-social-providers-config.ts
@@ -1,0 +1,30 @@
+import { AuthModuleOptions } from "../auth-module-options.interface";
+import { createSocialProviderConfig } from "./create-social-provider-config";
+
+type SocialProvidersConfig = NonNullable<AuthModuleOptions["socialProviders"]>;
+
+export function createSocialProvidersConfig(
+  disableSignUp: boolean,
+  options?: SocialProvidersConfig,
+): SocialProvidersConfig | undefined {
+  const githubConfig = createSocialProviderConfig(
+    "github",
+    disableSignUp,
+    options?.github,
+  );
+  const googleConfig = createSocialProviderConfig(
+    "google",
+    disableSignUp,
+    options?.google,
+  );
+
+  if (!options && !githubConfig && !googleConfig) {
+    return undefined;
+  }
+
+  return {
+    ...options,
+    ...(githubConfig ? { github: githubConfig } : {}),
+    ...(googleConfig ? { google: googleConfig } : {}),
+  };
+}

--- a/packages/auth/src/utils/generic-oauth-provider-config.type.ts
+++ b/packages/auth/src/utils/generic-oauth-provider-config.type.ts
@@ -1,0 +1,7 @@
+import { type genericOAuth } from "better-auth/plugins";
+
+export type GenericOAuthProviderConfig = Parameters<
+  typeof genericOAuth
+>[0]["config"][number];
+
+export type OidcPrompt = NonNullable<GenericOAuthProviderConfig["prompt"]>;

--- a/packages/auth/src/utils/has-oidc-env-config.spec.ts
+++ b/packages/auth/src/utils/has-oidc-env-config.spec.ts
@@ -7,6 +7,7 @@ describe("hasOidcEnvConfig", () => {
     delete process.env.AUTH_OIDC_CLIENT_SECRET;
     delete process.env.AUTH_OIDC_DISCOVERY_URL;
     delete process.env.AUTH_OIDC_DISABLE_SIGNUP;
+    delete process.env.AUTH_OIDC_ENABLED;
     delete process.env.AUTH_OIDC_PROMPT;
     delete process.env.AUTH_OIDC_SCOPES;
   });

--- a/packages/auth/src/utils/has-oidc-env-config.spec.ts
+++ b/packages/auth/src/utils/has-oidc-env-config.spec.ts
@@ -1,0 +1,26 @@
+import { hasOidcEnvConfig } from "./has-oidc-env-config";
+import { OIDC_ENV_NAMES } from "./oidc.constants";
+
+describe("hasOidcEnvConfig", () => {
+  beforeEach(() => {
+    delete process.env.AUTH_OIDC_CLIENT_ID;
+    delete process.env.AUTH_OIDC_CLIENT_SECRET;
+    delete process.env.AUTH_OIDC_DISCOVERY_URL;
+    delete process.env.AUTH_OIDC_DISABLE_SIGNUP;
+    delete process.env.AUTH_OIDC_PROMPT;
+    delete process.env.AUTH_OIDC_SCOPES;
+  });
+
+  it("should return false when OIDC env is not configured", () => {
+    expect(hasOidcEnvConfig()).toBe(false);
+  });
+
+  it.each(OIDC_ENV_NAMES)(
+    "should return true when %s is configured",
+    (name) => {
+      process.env[name] = "";
+
+      expect(hasOidcEnvConfig()).toBe(true);
+    },
+  );
+});

--- a/packages/auth/src/utils/has-oidc-env-config.ts
+++ b/packages/auth/src/utils/has-oidc-env-config.ts
@@ -1,0 +1,5 @@
+import { OIDC_ENV_NAMES } from "./oidc.constants";
+
+export function hasOidcEnvConfig(): boolean {
+  return OIDC_ENV_NAMES.some((name) => process.env[name] !== undefined);
+}

--- a/packages/auth/src/utils/has-social-provider-credential-env-config.spec.ts
+++ b/packages/auth/src/utils/has-social-provider-credential-env-config.spec.ts
@@ -1,0 +1,32 @@
+import { hasSocialProviderCredentialEnvConfig } from "./has-social-provider-credential-env-config";
+
+describe("hasSocialProviderCredentialEnvConfig", () => {
+  beforeEach(() => {
+    delete process.env.AUTH_GITHUB_CLIENT_ID;
+    delete process.env.AUTH_GITHUB_CLIENT_SECRET;
+    delete process.env.AUTH_GITHUB_DISABLE_SIGNUP;
+    delete process.env.AUTH_GOOGLE_CLIENT_ID;
+    delete process.env.AUTH_GOOGLE_CLIENT_SECRET;
+    delete process.env.AUTH_GOOGLE_DISABLE_SIGNUP;
+  });
+
+  it("should return false when only disable signup env is configured", () => {
+    process.env.AUTH_GOOGLE_DISABLE_SIGNUP = "true";
+
+    expect(hasSocialProviderCredentialEnvConfig("google")).toBe(false);
+  });
+
+  it.each([
+    ["github", "AUTH_GITHUB_CLIENT_ID"],
+    ["github", "AUTH_GITHUB_CLIENT_SECRET"],
+    ["google", "AUTH_GOOGLE_CLIENT_ID"],
+    ["google", "AUTH_GOOGLE_CLIENT_SECRET"],
+  ] as const)(
+    "should return true when %s credential env %s is configured",
+    (provider, name) => {
+      process.env[name] = "";
+
+      expect(hasSocialProviderCredentialEnvConfig(provider)).toBe(true);
+    },
+  );
+});

--- a/packages/auth/src/utils/has-social-provider-credential-env-config.spec.ts
+++ b/packages/auth/src/utils/has-social-provider-credential-env-config.spec.ts
@@ -5,13 +5,21 @@ describe("hasSocialProviderCredentialEnvConfig", () => {
     delete process.env.AUTH_GITHUB_CLIENT_ID;
     delete process.env.AUTH_GITHUB_CLIENT_SECRET;
     delete process.env.AUTH_GITHUB_DISABLE_SIGNUP;
+    delete process.env.AUTH_GITHUB_ENABLED;
     delete process.env.AUTH_GOOGLE_CLIENT_ID;
     delete process.env.AUTH_GOOGLE_CLIENT_SECRET;
     delete process.env.AUTH_GOOGLE_DISABLE_SIGNUP;
+    delete process.env.AUTH_GOOGLE_ENABLED;
   });
 
   it("should return false when only disable signup env is configured", () => {
     process.env.AUTH_GOOGLE_DISABLE_SIGNUP = "true";
+
+    expect(hasSocialProviderCredentialEnvConfig("google")).toBe(false);
+  });
+
+  it("should return false when only enabled env is configured", () => {
+    process.env.AUTH_GOOGLE_ENABLED = "true";
 
     expect(hasSocialProviderCredentialEnvConfig("google")).toBe(false);
   });

--- a/packages/auth/src/utils/has-social-provider-credential-env-config.ts
+++ b/packages/auth/src/utils/has-social-provider-credential-env-config.ts
@@ -1,0 +1,15 @@
+import {
+  SOCIAL_PROVIDER_ENV_CONFIGS,
+  SocialProviderId,
+} from "./social-provider.constants";
+
+export function hasSocialProviderCredentialEnvConfig(
+  provider: SocialProviderId,
+): boolean {
+  const config = SOCIAL_PROVIDER_ENV_CONFIGS[provider];
+
+  return (
+    process.env[config.clientId] !== undefined ||
+    process.env[config.clientSecret] !== undefined
+  );
+}

--- a/packages/auth/src/utils/has-social-provider-env-config.spec.ts
+++ b/packages/auth/src/utils/has-social-provider-env-config.spec.ts
@@ -5,9 +5,11 @@ const socialProviderEnvCases = [
   ["github", "AUTH_GITHUB_CLIENT_ID"],
   ["github", "AUTH_GITHUB_CLIENT_SECRET"],
   ["github", "AUTH_GITHUB_DISABLE_SIGNUP"],
+  ["github", "AUTH_GITHUB_ENABLED"],
   ["google", "AUTH_GOOGLE_CLIENT_ID"],
   ["google", "AUTH_GOOGLE_CLIENT_SECRET"],
   ["google", "AUTH_GOOGLE_DISABLE_SIGNUP"],
+  ["google", "AUTH_GOOGLE_ENABLED"],
 ] as const;
 
 describe("hasSocialProviderEnvConfig", () => {
@@ -15,9 +17,11 @@ describe("hasSocialProviderEnvConfig", () => {
     delete process.env.AUTH_GITHUB_CLIENT_ID;
     delete process.env.AUTH_GITHUB_CLIENT_SECRET;
     delete process.env.AUTH_GITHUB_DISABLE_SIGNUP;
+    delete process.env.AUTH_GITHUB_ENABLED;
     delete process.env.AUTH_GOOGLE_CLIENT_ID;
     delete process.env.AUTH_GOOGLE_CLIENT_SECRET;
     delete process.env.AUTH_GOOGLE_DISABLE_SIGNUP;
+    delete process.env.AUTH_GOOGLE_ENABLED;
   });
 
   it.each(socialProviderIds)(

--- a/packages/auth/src/utils/has-social-provider-env-config.spec.ts
+++ b/packages/auth/src/utils/has-social-provider-env-config.spec.ts
@@ -1,0 +1,38 @@
+import { hasSocialProviderEnvConfig } from "./has-social-provider-env-config";
+
+const socialProviderIds = ["github", "google"] as const;
+const socialProviderEnvCases = [
+  ["github", "AUTH_GITHUB_CLIENT_ID"],
+  ["github", "AUTH_GITHUB_CLIENT_SECRET"],
+  ["github", "AUTH_GITHUB_DISABLE_SIGNUP"],
+  ["google", "AUTH_GOOGLE_CLIENT_ID"],
+  ["google", "AUTH_GOOGLE_CLIENT_SECRET"],
+  ["google", "AUTH_GOOGLE_DISABLE_SIGNUP"],
+] as const;
+
+describe("hasSocialProviderEnvConfig", () => {
+  beforeEach(() => {
+    delete process.env.AUTH_GITHUB_CLIENT_ID;
+    delete process.env.AUTH_GITHUB_CLIENT_SECRET;
+    delete process.env.AUTH_GITHUB_DISABLE_SIGNUP;
+    delete process.env.AUTH_GOOGLE_CLIENT_ID;
+    delete process.env.AUTH_GOOGLE_CLIENT_SECRET;
+    delete process.env.AUTH_GOOGLE_DISABLE_SIGNUP;
+  });
+
+  it.each(socialProviderIds)(
+    "should return false when %s env is not configured",
+    (provider) => {
+      expect(hasSocialProviderEnvConfig(provider)).toBe(false);
+    },
+  );
+
+  it.each(socialProviderEnvCases)(
+    "should return true when %s env %s is configured",
+    (provider, name) => {
+      process.env[name] = "";
+
+      expect(hasSocialProviderEnvConfig(provider)).toBe(true);
+    },
+  );
+});

--- a/packages/auth/src/utils/has-social-provider-env-config.ts
+++ b/packages/auth/src/utils/has-social-provider-env-config.ts
@@ -1,0 +1,12 @@
+import {
+  SOCIAL_PROVIDER_ENV_CONFIGS,
+  SocialProviderId,
+} from "./social-provider.constants";
+
+export function hasSocialProviderEnvConfig(
+  provider: SocialProviderId,
+): boolean {
+  return SOCIAL_PROVIDER_ENV_CONFIGS[provider].envNames.some(
+    (name) => process.env[name] !== undefined,
+  );
+}

--- a/packages/auth/src/utils/is-env-true.spec.ts
+++ b/packages/auth/src/utils/is-env-true.spec.ts
@@ -1,0 +1,23 @@
+import { isEnvTrue } from "./is-env-true";
+
+describe("isEnvTrue", () => {
+  beforeEach(() => {
+    delete process.env.TEST_ENV_BOOLEAN;
+  });
+
+  it("should return true only when the env value is true", () => {
+    process.env.TEST_ENV_BOOLEAN = "true";
+
+    expect(isEnvTrue("TEST_ENV_BOOLEAN")).toBe(true);
+  });
+
+  it.each(["false", "1", "TRUE", ""])("should return false for %s", (value) => {
+    process.env.TEST_ENV_BOOLEAN = value;
+
+    expect(isEnvTrue("TEST_ENV_BOOLEAN")).toBe(false);
+  });
+
+  it("should return false when the env value is unset", () => {
+    expect(isEnvTrue("TEST_ENV_BOOLEAN")).toBe(false);
+  });
+});

--- a/packages/auth/src/utils/is-env-true.ts
+++ b/packages/auth/src/utils/is-env-true.ts
@@ -1,0 +1,3 @@
+export function isEnvTrue(name: string): boolean {
+  return process.env[name] === "true";
+}

--- a/packages/auth/src/utils/oidc.constants.ts
+++ b/packages/auth/src/utils/oidc.constants.ts
@@ -1,0 +1,28 @@
+import { OidcPrompt } from "./generic-oauth-provider-config.type";
+
+export const OIDC_ENV_NAMES = [
+  "AUTH_OIDC_CLIENT_ID",
+  "AUTH_OIDC_CLIENT_SECRET",
+  "AUTH_OIDC_DISCOVERY_URL",
+  "AUTH_OIDC_DISABLE_SIGNUP",
+  "AUTH_OIDC_PROMPT",
+  "AUTH_OIDC_SCOPES",
+] as const;
+
+export const REQUIRED_OIDC_ENV_NAMES = [
+  "AUTH_OIDC_CLIENT_ID",
+  "AUTH_OIDC_CLIENT_SECRET",
+  "AUTH_OIDC_DISCOVERY_URL",
+] as const;
+
+export const OIDC_PROMPTS: readonly OidcPrompt[] = [
+  "none",
+  "login",
+  "create",
+  "consent",
+  "select_account",
+  "select_account consent",
+  "login consent",
+];
+
+export type RequiredOidcEnvName = (typeof REQUIRED_OIDC_ENV_NAMES)[number];

--- a/packages/auth/src/utils/oidc.constants.ts
+++ b/packages/auth/src/utils/oidc.constants.ts
@@ -1,6 +1,7 @@
 import { OidcPrompt } from "./generic-oauth-provider-config.type";
 
 export const OIDC_ENV_NAMES = [
+  "AUTH_OIDC_ENABLED",
   "AUTH_OIDC_CLIENT_ID",
   "AUTH_OIDC_CLIENT_SECRET",
   "AUTH_OIDC_DISCOVERY_URL",

--- a/packages/auth/src/utils/resolve-oidc-prompt.spec.ts
+++ b/packages/auth/src/utils/resolve-oidc-prompt.spec.ts
@@ -1,0 +1,31 @@
+import { resolveOidcPrompt } from "./resolve-oidc-prompt";
+
+describe("resolveOidcPrompt", () => {
+  beforeEach(() => {
+    delete process.env.AUTH_OIDC_PROMPT;
+  });
+
+  it("should return undefined when AUTH_OIDC_PROMPT is unset", () => {
+    expect(resolveOidcPrompt()).toBeUndefined();
+  });
+
+  it.each([
+    "none",
+    "login",
+    "create",
+    "consent",
+    "select_account",
+    "select_account consent",
+    "login consent",
+  ])("should return supported prompt %s", (prompt) => {
+    process.env.AUTH_OIDC_PROMPT = prompt;
+
+    expect(resolveOidcPrompt()).toBe(prompt);
+  });
+
+  it("should reject unsupported prompt values", () => {
+    process.env.AUTH_OIDC_PROMPT = "invalid";
+
+    expect(() => resolveOidcPrompt()).toThrow("AUTH_OIDC_PROMPT");
+  });
+});

--- a/packages/auth/src/utils/resolve-oidc-prompt.ts
+++ b/packages/auth/src/utils/resolve-oidc-prompt.ts
@@ -1,0 +1,22 @@
+import {
+  GenericOAuthProviderConfig,
+  OidcPrompt,
+} from "./generic-oauth-provider-config.type";
+import { OIDC_PROMPTS } from "./oidc.constants";
+
+export function resolveOidcPrompt(): GenericOAuthProviderConfig["prompt"] {
+  const prompt = process.env.AUTH_OIDC_PROMPT;
+
+  if (!prompt) {
+    return undefined;
+  }
+
+  if (!OIDC_PROMPTS.includes(prompt as OidcPrompt)) {
+    throw new Error(
+      "AUTH_OIDC_PROMPT is invalid.\n" +
+        `Set AUTH_OIDC_PROMPT to one of: ${OIDC_PROMPTS.join(", ")}.`,
+    );
+  }
+
+  return prompt as OidcPrompt;
+}

--- a/packages/auth/src/utils/resolve-oidc-scopes.spec.ts
+++ b/packages/auth/src/utils/resolve-oidc-scopes.spec.ts
@@ -1,0 +1,17 @@
+import { resolveOidcScopes } from "./resolve-oidc-scopes";
+
+describe("resolveOidcScopes", () => {
+  beforeEach(() => {
+    delete process.env.AUTH_OIDC_SCOPES;
+  });
+
+  it("should return default scopes when AUTH_OIDC_SCOPES is unset", () => {
+    expect(resolveOidcScopes()).toEqual(["openid", "profile", "email"]);
+  });
+
+  it("should trim comma-separated scopes and drop blanks", () => {
+    process.env.AUTH_OIDC_SCOPES = "openid, profile, email,";
+
+    expect(resolveOidcScopes()).toEqual(["openid", "profile", "email"]);
+  });
+});

--- a/packages/auth/src/utils/resolve-oidc-scopes.ts
+++ b/packages/auth/src/utils/resolve-oidc-scopes.ts
@@ -1,0 +1,6 @@
+export function resolveOidcScopes(): string[] {
+  return (process.env.AUTH_OIDC_SCOPES ?? "openid,profile,email")
+    .split(",")
+    .map((scope) => scope.trim())
+    .filter(Boolean);
+}

--- a/packages/auth/src/utils/resolve-required-oidc-env.spec.ts
+++ b/packages/auth/src/utils/resolve-required-oidc-env.spec.ts
@@ -1,0 +1,25 @@
+import { resolveRequiredOidcEnv } from "./resolve-required-oidc-env";
+
+describe("resolveRequiredOidcEnv", () => {
+  beforeEach(() => {
+    delete process.env.AUTH_OIDC_CLIENT_ID;
+  });
+
+  it("should return the configured env value", () => {
+    process.env.AUTH_OIDC_CLIENT_ID = "client-id";
+
+    expect(resolveRequiredOidcEnv("AUTH_OIDC_CLIENT_ID")).toBe("client-id");
+  });
+
+  it.each([undefined, ""])("should reject missing values", (value) => {
+    if (value === undefined) {
+      delete process.env.AUTH_OIDC_CLIENT_ID;
+    } else {
+      process.env.AUTH_OIDC_CLIENT_ID = value;
+    }
+
+    expect(() => resolveRequiredOidcEnv("AUTH_OIDC_CLIENT_ID")).toThrow(
+      "AUTH_OIDC_CLIENT_ID",
+    );
+  });
+});

--- a/packages/auth/src/utils/resolve-required-oidc-env.ts
+++ b/packages/auth/src/utils/resolve-required-oidc-env.ts
@@ -1,0 +1,14 @@
+import { RequiredOidcEnvName } from "./oidc.constants";
+
+export function resolveRequiredOidcEnv(name: RequiredOidcEnvName): string {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(
+      `${name} is required when OIDC auth is configured.\n` +
+        `Set ${name} environment variable, or remove AUTH_OIDC_* environment variables to disable OIDC auth.`,
+    );
+  }
+
+  return value;
+}

--- a/packages/auth/src/utils/resolve-required-oidc-env.ts
+++ b/packages/auth/src/utils/resolve-required-oidc-env.ts
@@ -6,7 +6,7 @@ export function resolveRequiredOidcEnv(name: RequiredOidcEnvName): string {
   if (!value) {
     throw new Error(
       `${name} is required when OIDC auth is configured.\n` +
-        `Set ${name} environment variable, or remove AUTH_OIDC_* environment variables to disable OIDC auth.`,
+        `Set ${name} environment variable, or set AUTH_OIDC_ENABLED=false to disable OIDC auth.`,
     );
   }
 

--- a/packages/auth/src/utils/resolve-required-social-provider-env.spec.ts
+++ b/packages/auth/src/utils/resolve-required-social-provider-env.spec.ts
@@ -1,0 +1,32 @@
+import { resolveRequiredSocialProviderEnv } from "./resolve-required-social-provider-env";
+
+describe("resolveRequiredSocialProviderEnv", () => {
+  beforeEach(() => {
+    delete process.env.AUTH_GITHUB_CLIENT_ID;
+    delete process.env.AUTH_GITHUB_CLIENT_SECRET;
+    delete process.env.AUTH_GITHUB_DISABLE_SIGNUP;
+    delete process.env.AUTH_GOOGLE_CLIENT_ID;
+    delete process.env.AUTH_GOOGLE_CLIENT_SECRET;
+    delete process.env.AUTH_GOOGLE_DISABLE_SIGNUP;
+  });
+
+  it("should return the configured env value", () => {
+    process.env.AUTH_GOOGLE_CLIENT_ID = "google-client-id";
+
+    expect(resolveRequiredSocialProviderEnv("google", "clientId")).toBe(
+      "google-client-id",
+    );
+  });
+
+  it.each([undefined, ""])("should reject missing values", (value) => {
+    if (value === undefined) {
+      delete process.env.AUTH_GITHUB_CLIENT_SECRET;
+    } else {
+      process.env.AUTH_GITHUB_CLIENT_SECRET = value;
+    }
+
+    expect(() =>
+      resolveRequiredSocialProviderEnv("github", "clientSecret"),
+    ).toThrow("AUTH_GITHUB_CLIENT_SECRET");
+  });
+});

--- a/packages/auth/src/utils/resolve-required-social-provider-env.spec.ts
+++ b/packages/auth/src/utils/resolve-required-social-provider-env.spec.ts
@@ -5,9 +5,11 @@ describe("resolveRequiredSocialProviderEnv", () => {
     delete process.env.AUTH_GITHUB_CLIENT_ID;
     delete process.env.AUTH_GITHUB_CLIENT_SECRET;
     delete process.env.AUTH_GITHUB_DISABLE_SIGNUP;
+    delete process.env.AUTH_GITHUB_ENABLED;
     delete process.env.AUTH_GOOGLE_CLIENT_ID;
     delete process.env.AUTH_GOOGLE_CLIENT_SECRET;
     delete process.env.AUTH_GOOGLE_DISABLE_SIGNUP;
+    delete process.env.AUTH_GOOGLE_ENABLED;
   });
 
   it("should return the configured env value", () => {

--- a/packages/auth/src/utils/resolve-required-social-provider-env.ts
+++ b/packages/auth/src/utils/resolve-required-social-provider-env.ts
@@ -15,7 +15,7 @@ export function resolveRequiredSocialProviderEnv(
   if (!value) {
     throw new Error(
       `${name} is required for ${config.displayName} auth.\n` +
-        `Set ${name} environment variable, or remove ${config.envPrefix} environment variables to disable ${config.displayName} auth.`,
+        `Set ${name} environment variable, or set ${config.enabled}=false to disable ${config.displayName} auth.`,
     );
   }
 

--- a/packages/auth/src/utils/resolve-required-social-provider-env.ts
+++ b/packages/auth/src/utils/resolve-required-social-provider-env.ts
@@ -1,0 +1,23 @@
+import {
+  SOCIAL_PROVIDER_ENV_CONFIGS,
+  SocialProviderId,
+  SocialProviderRequiredEnvKey,
+} from "./social-provider.constants";
+
+export function resolveRequiredSocialProviderEnv(
+  provider: SocialProviderId,
+  key: SocialProviderRequiredEnvKey,
+): string {
+  const config = SOCIAL_PROVIDER_ENV_CONFIGS[provider];
+  const name = config[key];
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(
+      `${name} is required for ${config.displayName} auth.\n` +
+        `Set ${name} environment variable, or remove ${config.envPrefix} environment variables to disable ${config.displayName} auth.`,
+    );
+  }
+
+  return value;
+}

--- a/packages/auth/src/utils/resolve-secret.spec.ts
+++ b/packages/auth/src/utils/resolve-secret.spec.ts
@@ -1,0 +1,50 @@
+import { AuthModuleOptions } from "../auth-module-options.interface";
+import { resolveSecret } from "./resolve-secret";
+
+describe("resolveSecret", () => {
+  const secret =
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_abcdefghijklmnopqrstuvwxyz";
+
+  beforeEach(() => {
+    delete process.env.APP_SECRET;
+    delete process.env.AUTH_SECRET;
+  });
+
+  it("should prefer the explicit module option", () => {
+    process.env.AUTH_SECRET =
+      "AUTHabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_";
+
+    expect(
+      resolveSecret({
+        secret,
+      } as AuthModuleOptions),
+    ).toBe(secret);
+  });
+
+  it("should fall back to AUTH_SECRET and APP_SECRET env values", () => {
+    process.env.AUTH_SECRET = secret;
+
+    expect(resolveSecret({} as AuthModuleOptions)).toBe(secret);
+
+    delete process.env.AUTH_SECRET;
+    process.env.APP_SECRET = secret;
+
+    expect(resolveSecret({} as AuthModuleOptions)).toBe(secret);
+  });
+
+  it("should reject missing, short, or low-entropy secrets", () => {
+    expect(() => resolveSecret({} as AuthModuleOptions)).toThrow(
+      "Auth secret is required",
+    );
+    expect(() =>
+      resolveSecret({
+        secret: "short",
+      } as AuthModuleOptions),
+    ).toThrow("Auth secret must be at least 32 characters long");
+    expect(() =>
+      resolveSecret({
+        secret: "a".repeat(32),
+      } as AuthModuleOptions),
+    ).toThrow("Auth secret appears low-entropy");
+  });
+});

--- a/packages/auth/src/utils/resolve-secret.ts
+++ b/packages/auth/src/utils/resolve-secret.ts
@@ -1,0 +1,36 @@
+import { AuthModuleOptions } from "../auth-module-options.interface";
+import { estimateEntropy } from "./estimate-entropy";
+
+export function resolveSecret(options: AuthModuleOptions): string {
+  const secret =
+    options.secret ?? process.env.AUTH_SECRET ?? process.env.APP_SECRET;
+
+  if (!secret) {
+    throw new Error(
+      "Auth secret is required.\n" +
+        "Set AUTH_SECRET or APP_SECRET environment variable, or pass a secret option.\n" +
+        "Generate a secure secret with:\n" +
+        "  node -e \"console.log(require('crypto').randomBytes(32).toString('base64url'))\"",
+    );
+  }
+
+  if (secret.length < 32) {
+    throw new Error(
+      "Auth secret must be at least 32 characters long.\n" +
+        "Set AUTH_SECRET or APP_SECRET environment variable, or pass a secret option.\n" +
+        "Generate a secure secret with:\n" +
+        "  node -e \"console.log(require('crypto').randomBytes(32).toString('base64url'))\"",
+    );
+  }
+
+  if (estimateEntropy(secret) < 120) {
+    throw new Error(
+      "Auth secret appears low-entropy.\n" +
+        "Use a randomly generated secret for production.\n" +
+        "Generate a secure secret with:\n" +
+        "  node -e \"console.log(require('crypto').randomBytes(32).toString('base64url'))\"",
+    );
+  }
+
+  return secret;
+}

--- a/packages/auth/src/utils/resolve-social-provider-enabled.spec.ts
+++ b/packages/auth/src/utils/resolve-social-provider-enabled.spec.ts
@@ -1,0 +1,21 @@
+import { resolveSocialProviderEnabled } from "./resolve-social-provider-enabled";
+
+describe("resolveSocialProviderEnabled", () => {
+  beforeEach(() => {
+    delete process.env.AUTH_GOOGLE_ENABLED;
+  });
+
+  it("should return false when provider enabled env is unset", () => {
+    expect(resolveSocialProviderEnabled("google")).toBe(false);
+  });
+
+  it.each([
+    ["true", true],
+    ["false", false],
+    ["1", false],
+  ] as const)("should parse %s as %s", (value, expected) => {
+    process.env.AUTH_GOOGLE_ENABLED = value;
+
+    expect(resolveSocialProviderEnabled("google")).toBe(expected);
+  });
+});

--- a/packages/auth/src/utils/resolve-social-provider-enabled.ts
+++ b/packages/auth/src/utils/resolve-social-provider-enabled.ts
@@ -1,0 +1,12 @@
+import {
+  SOCIAL_PROVIDER_ENV_CONFIGS,
+  SocialProviderId,
+} from "./social-provider.constants";
+
+export function resolveSocialProviderEnabled(
+  provider: SocialProviderId,
+): boolean {
+  const value = process.env[SOCIAL_PROVIDER_ENV_CONFIGS[provider].enabled];
+
+  return value === "true";
+}

--- a/packages/auth/src/utils/social-provider.constants.ts
+++ b/packages/auth/src/utils/social-provider.constants.ts
@@ -1,0 +1,30 @@
+export const SOCIAL_PROVIDER_ENV_CONFIGS = {
+  github: {
+    displayName: "GitHub",
+    clientId: "AUTH_GITHUB_CLIENT_ID",
+    clientSecret: "AUTH_GITHUB_CLIENT_SECRET",
+    disableSignUp: "AUTH_GITHUB_DISABLE_SIGNUP",
+    envPrefix: "AUTH_GITHUB_*",
+    envNames: [
+      "AUTH_GITHUB_CLIENT_ID",
+      "AUTH_GITHUB_CLIENT_SECRET",
+      "AUTH_GITHUB_DISABLE_SIGNUP",
+    ],
+  },
+  google: {
+    displayName: "Google",
+    clientId: "AUTH_GOOGLE_CLIENT_ID",
+    clientSecret: "AUTH_GOOGLE_CLIENT_SECRET",
+    disableSignUp: "AUTH_GOOGLE_DISABLE_SIGNUP",
+    envPrefix: "AUTH_GOOGLE_*",
+    envNames: [
+      "AUTH_GOOGLE_CLIENT_ID",
+      "AUTH_GOOGLE_CLIENT_SECRET",
+      "AUTH_GOOGLE_DISABLE_SIGNUP",
+    ],
+  },
+} as const;
+
+export type SocialProviderId = keyof typeof SOCIAL_PROVIDER_ENV_CONFIGS;
+
+export type SocialProviderRequiredEnvKey = "clientId" | "clientSecret";

--- a/packages/auth/src/utils/social-provider.constants.ts
+++ b/packages/auth/src/utils/social-provider.constants.ts
@@ -4,11 +4,13 @@ export const SOCIAL_PROVIDER_ENV_CONFIGS = {
     clientId: "AUTH_GITHUB_CLIENT_ID",
     clientSecret: "AUTH_GITHUB_CLIENT_SECRET",
     disableSignUp: "AUTH_GITHUB_DISABLE_SIGNUP",
+    enabled: "AUTH_GITHUB_ENABLED",
     envPrefix: "AUTH_GITHUB_*",
     envNames: [
       "AUTH_GITHUB_CLIENT_ID",
       "AUTH_GITHUB_CLIENT_SECRET",
       "AUTH_GITHUB_DISABLE_SIGNUP",
+      "AUTH_GITHUB_ENABLED",
     ],
   },
   google: {
@@ -16,11 +18,13 @@ export const SOCIAL_PROVIDER_ENV_CONFIGS = {
     clientId: "AUTH_GOOGLE_CLIENT_ID",
     clientSecret: "AUTH_GOOGLE_CLIENT_SECRET",
     disableSignUp: "AUTH_GOOGLE_DISABLE_SIGNUP",
+    enabled: "AUTH_GOOGLE_ENABLED",
     envPrefix: "AUTH_GOOGLE_*",
     envNames: [
       "AUTH_GOOGLE_CLIENT_ID",
       "AUTH_GOOGLE_CLIENT_SECRET",
       "AUTH_GOOGLE_DISABLE_SIGNUP",
+      "AUTH_GOOGLE_ENABLED",
     ],
   },
 } as const;


### PR DESCRIPTION
## Summary
- Add AuthModule environment-variable configuration for app metadata, email/password auth, generic OIDC, Google, GitHub, and signup disabling.
- Gate Google, GitHub, and generic OIDC env providers behind explicit `AUTH_*_ENABLED=true`, with startup validation and clear errors for required credentials.
- Move auth env helper logic into focused `utils` files with dedicated tests, trim OIDC scopes, reject duplicate env/custom generic OAuth plugins, and document the new env variables in English and Chinese Auth tutorials.

## Test Plan
- `pnpm --filter @nest-boot/auth exec jest --runInBand`
- `pnpm --filter @nest-boot/auth lint`
- `pnpm --filter @nest-boot/auth build`
- `pnpm exec prettier --check apps/docs/content/docs/tutorial/auth.mdx apps/docs/content/docs/tutorial/auth.zh-Hans.mdx`
- `pnpm --filter @nest-boot/docs types:check`
- commit hook: `pnpm docs:check`