### PR TITLE
chore: relax commit body lint

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,3 +1,7 @@
 module.exports = {
   extends: ["@commitlint/config-conventional"],
+  rules: {
+    "body-max-line-length": [0],
+    "footer-max-line-length": [0],
+  },
 };


### PR DESCRIPTION
## Summary
- Disable commitlint body and footer line-length checks so generated squash commit bodies and release metadata do not fail `commitlint --last`.

## Test Plan
- `printf '%s\n\n%s\n' 'chore: test relaxed commit body length' 'This is an intentionally long commit body line that exceeds one hundred characters so commitlint should accept it after disabling body-max-line-length.' | pnpm commitlint --verbose`
- `pnpm commitlint --last --verbose`
- commit hook: `pnpm docs:check`