### PR TITLE
chore(auth): prepare 7.11.0 release

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -121,7 +121,6 @@ jobs:
 
       - name: Release packages
         if: inputs.release
-        run: pnpm exec nx release --yes
+        run: pnpm exec nx release publish --projects=@nest-boot/auth --yes
         env:
-          GITHUB_TOKEN: ${{ github.token }}
           NPM_CONFIG_PROVENANCE: true

--- a/packages/auth/CHANGELOG.md
+++ b/packages/auth/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 7.11.0 (2026-06-07)
+
+### 🚀 Features
+
+- **auth:** support env-configured auth providers ([7b1bf46](https://github.com/nest-boot/nest-boot/commit/7b1bf46))
+
+### ❤️ Thank You
+
+- Xudong Huang @xudongcc
+
 # @nest-boot/auth
 
 ## 7.10.0

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/auth",
-  "version": "7.10.0",
+  "version": "7.11.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",


### PR DESCRIPTION
## Summary
- Bump `@nest-boot/auth` to `7.11.0` and add the release changelog entry.
- Change the Release workflow release step to publish `@nest-boot/auth` only, avoiding `nx release` version/changelog git pushes to protected `master`.

## Test Plan
- `pnpm --filter @nest-boot/auth build`
- `pnpm nx release publish --projects=@nest-boot/auth --dry-run`
- commit hook: `pnpm docs:check`