### PR TITLE
fix(release): run semantic package release

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -121,6 +121,6 @@ jobs:
 
       - name: Release packages
         if: inputs.release
-        run: pnpm exec nx release publish --projects=@nest-boot/auth --yes
+        run: pnpm exec nx release --yes
         env:
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary
- run the full Nx semantic release flow in the release workflow
- let Nx conventional commits and independent release config decide which packages should version and publish
- stop hard-coding @nest-boot/auth in the publish command

## Verification
- pnpm exec nx release --skip-publish --dry-run
- commit hook: pnpm build:packages && pnpm typedoc:check