### PR TITLE
fix(release): publish versioned packages only

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -121,6 +121,6 @@ jobs:
 
       - name: Release packages
         if: inputs.release
-        run: pnpm exec nx release --yes
+        run: pnpm exec nx release publish --yes
         env:
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary
- use the Nx publish subcommand in the release workflow
- stop attempting to create release commits directly on protected master
- let Nx publish all versioned packages instead of hard-coding @nest-boot/auth

## Verification
- git diff --check
- pnpm exec nx release publish --help