### PR TITLE
chore(release): publish

### DIFF
--- a/packages/auth/CHANGELOG.md
+++ b/packages/auth/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 7.11.1 (2026-06-07)
+
+### 🩹 Fixes
+
+- **auth:** rename signup disable env vars ([1a1001b](https://github.com/nest-boot/nest-boot/commit/1a1001b))
+
+### 🧱 Updated Dependencies
+
+- Updated @nest-boot/request-context to 7.5.0
+- Updated @nest-boot/eslint-config to 7.1.0
+- Updated @nest-boot/eslint-plugin to 7.0.8
+- Updated @nest-boot/middleware to 7.4.0
+- Updated @nest-boot/tsconfig to 7.1.0
+
+### ❤️ Thank You
+
+- Xudong Huang @xudongcc
+
 ## 7.11.0 (2026-06-07)
 
 ### 🚀 Features

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/auth",
-  "version": "7.11.0",
+  "version": "7.11.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",

--- a/packages/bullmq-mikro-orm/CHANGELOG.md
+++ b/packages/bullmq-mikro-orm/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 7.1.0 (2026-06-07)
+
+### 🚀 Features
+
+- add row level security driver ([#236](https://github.com/nest-boot/nest-boot/pull/236))
+
+### 🧱 Updated Dependencies
+
+- Updated @nest-boot/request-context to 7.5.0
+- Updated @nest-boot/eslint-config to 7.1.0
+- Updated @nest-boot/eslint-plugin to 7.0.8
+- Updated @nest-boot/schedule to 7.1.0
+- Updated @nest-boot/tsconfig to 7.1.0
+- Updated @nest-boot/bullmq to 7.1.0
+
+### ❤️ Thank You
+
+- Xudong Huang @xudongcc
+
 # @nest-boot/bullmq-mikro-orm
 
 ## 7.0.5

--- a/packages/bullmq-mikro-orm/package.json
+++ b/packages/bullmq-mikro-orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/bullmq-mikro-orm",
-  "version": "7.0.5",
+  "version": "7.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",

--- a/packages/bullmq/CHANGELOG.md
+++ b/packages/bullmq/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 7.1.0 (2026-06-07)
+
+### 🚀 Features
+
+- add row level security driver ([#236](https://github.com/nest-boot/nest-boot/pull/236))
+
+### 🧱 Updated Dependencies
+
+- Updated @nest-boot/request-context to 7.5.0
+- Updated @nest-boot/eslint-config to 7.1.0
+- Updated @nest-boot/eslint-plugin to 7.0.8
+- Updated @nest-boot/tsconfig to 7.1.0
+
+### ❤️ Thank You
+
+- Xudong Huang @xudongcc
+
 # @nest-boot/bullmq
 
 ## 7.0.3

--- a/packages/bullmq/package.json
+++ b/packages/bullmq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/bullmq",
-  "version": "7.0.3",
+  "version": "7.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",

--- a/packages/crypt/CHANGELOG.md
+++ b/packages/crypt/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 7.2.0 (2026-06-07)
+
+### 🚀 Features
+
+- add row level security driver ([#236](https://github.com/nest-boot/nest-boot/pull/236))
+
+### 🧱 Updated Dependencies
+
+- Updated @nest-boot/eslint-config to 7.1.0
+- Updated @nest-boot/eslint-plugin to 7.0.8
+- Updated @nest-boot/tsconfig to 7.1.0
+
+### ❤️ Thank You
+
+- Xudong Huang @xudongcc
+
 # @nest-boot/crypt
 
 ## 7.1.3

--- a/packages/crypt/package.json
+++ b/packages/crypt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/crypt",
-  "version": "7.1.3",
+  "version": "7.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 7.1.0 (2026-06-07)
+
+### 🚀 Features
+
+- add row level security driver ([#236](https://github.com/nest-boot/nest-boot/pull/236))
+
+### 🧱 Updated Dependencies
+
+- Updated @nest-boot/eslint-plugin to 7.0.8
+- Updated @nest-boot/tsconfig to 7.1.0
+
+### ❤️ Thank You
+
+- Xudong Huang @xudongcc
+
 # @nest-boot/eslint-config
 
 ## 7.0.3

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/eslint-config",
-  "version": "7.0.3",
+  "version": "7.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 7.0.8 (2026-06-07)
+
+### 🧱 Updated Dependencies
+
+- Updated @nest-boot/tsconfig to 7.1.0
+
 # @nest-boot/eslint-plugin
 
 ## 7.0.7

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/eslint-plugin",
-  "version": "7.0.7",
+  "version": "7.0.8",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",

--- a/packages/file-upload/CHANGELOG.md
+++ b/packages/file-upload/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 7.1.5 (2026-06-07)
+
+### 🧱 Updated Dependencies
+
+- Updated @nest-boot/eslint-config to 7.1.0
+- Updated @nest-boot/eslint-plugin to 7.0.8
+- Updated @nest-boot/tsconfig to 7.1.0
+- Updated @nest-boot/graphql to 7.1.5
+
 # @nest-boot/file-upload
 
 ## 7.1.4

--- a/packages/file-upload/package.json
+++ b/packages/file-upload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/file-upload",
-  "version": "7.1.4",
+  "version": "7.1.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",

--- a/packages/graphql-connection/CHANGELOG.md
+++ b/packages/graphql-connection/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 7.8.0 (2026-06-07)
+
+### 🚀 Features
+
+- add row level security driver ([#236](https://github.com/nest-boot/nest-boot/pull/236))
+
+### 🧱 Updated Dependencies
+
+- Updated @nest-boot/eslint-config to 7.1.0
+- Updated @nest-boot/eslint-plugin to 7.0.8
+- Updated @nest-boot/tsconfig to 7.1.0
+- Updated @nest-boot/graphql to 7.1.5
+
+### ❤️ Thank You
+
+- Xudong Huang @xudongcc
+
 # @nest-boot/graphql-connection
 
 ## 7.7.2

--- a/packages/graphql-connection/package.json
+++ b/packages/graphql-connection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/graphql-connection",
-  "version": "7.7.2",
+  "version": "7.8.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",

--- a/packages/graphql-logger/CHANGELOG.md
+++ b/packages/graphql-logger/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 7.1.0 (2026-06-07)
+
+### 🚀 Features
+
+- add row level security driver ([#236](https://github.com/nest-boot/nest-boot/pull/236))
+
+### 🧱 Updated Dependencies
+
+- Updated @nest-boot/eslint-config to 7.1.0
+- Updated @nest-boot/eslint-plugin to 7.0.8
+- Updated @nest-boot/tsconfig to 7.1.0
+- Updated @nest-boot/logger to 7.1.0
+
+### ❤️ Thank You
+
+- Xudong Huang @xudongcc
+
 # @nest-boot/graphql-logger
 
 ## 7.0.3

--- a/packages/graphql-logger/package.json
+++ b/packages/graphql-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/graphql-logger",
-  "version": "7.0.3",
+  "version": "7.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",

--- a/packages/graphql-rate-limit/CHANGELOG.md
+++ b/packages/graphql-rate-limit/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 7.2.0 (2026-06-07)
+
+### 🚀 Features
+
+- add row level security driver ([#236](https://github.com/nest-boot/nest-boot/pull/236))
+
+### 🧱 Updated Dependencies
+
+- Updated @nest-boot/eslint-config to 7.1.0
+- Updated @nest-boot/eslint-plugin to 7.0.8
+- Updated @nest-boot/tsconfig to 7.1.0
+- Updated @nest-boot/graphql to 7.1.5
+
+### ❤️ Thank You
+
+- Xudong Huang @xudongcc
+
 # @nest-boot/graphql-rate-limit
 
 ## 7.1.0

--- a/packages/graphql-rate-limit/package.json
+++ b/packages/graphql-rate-limit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/graphql-rate-limit",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",

--- a/packages/graphql/CHANGELOG.md
+++ b/packages/graphql/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 7.1.5 (2026-06-07)
+
+### 🧱 Updated Dependencies
+
+- Updated @nest-boot/eslint-config to 7.1.0
+- Updated @nest-boot/eslint-plugin to 7.0.8
+- Updated @nest-boot/tsconfig to 7.1.0
+
 # @nest-boot/graphql
 
 ## 7.1.4

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/graphql",
-  "version": "7.1.4",
+  "version": "7.1.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",

--- a/packages/hash/CHANGELOG.md
+++ b/packages/hash/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 7.3.0 (2026-06-07)
+
+### 🚀 Features
+
+- add row level security driver ([#236](https://github.com/nest-boot/nest-boot/pull/236))
+
+### 🧱 Updated Dependencies
+
+- Updated @nest-boot/eslint-config to 7.1.0
+- Updated @nest-boot/eslint-plugin to 7.0.8
+- Updated @nest-boot/tsconfig to 7.1.0
+
+### ❤️ Thank You
+
+- Xudong Huang @xudongcc
+
 # @nest-boot/hash
 
 ## 7.2.2

--- a/packages/hash/package.json
+++ b/packages/hash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/hash",
-  "version": "7.2.2",
+  "version": "7.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",

--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 7.1.0 (2026-06-07)
+
+### 🚀 Features
+
+- add row level security driver ([#236](https://github.com/nest-boot/nest-boot/pull/236))
+
+### 🧱 Updated Dependencies
+
+- Updated @nest-boot/request-context to 7.5.0
+- Updated @nest-boot/eslint-config to 7.1.0
+- Updated @nest-boot/eslint-plugin to 7.0.8
+- Updated @nest-boot/tsconfig to 7.1.0
+
+### ❤️ Thank You
+
+- Xudong Huang @xudongcc
+
 # @nest-boot/i18n
 
 ## 7.0.3

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/i18n",
-  "version": "7.0.3",
+  "version": "7.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 7.1.0 (2026-06-07)
+
+### 🚀 Features
+
+- add row level security driver ([#236](https://github.com/nest-boot/nest-boot/pull/236))
+
+### 🧱 Updated Dependencies
+
+- Updated @nest-boot/request-context to 7.5.0
+- Updated @nest-boot/eslint-config to 7.1.0
+- Updated @nest-boot/eslint-plugin to 7.0.8
+- Updated @nest-boot/tsconfig to 7.1.0
+
+### ❤️ Thank You
+
+- Xudong Huang @xudongcc
+
 # @nest-boot/logger
 
 ## 7.0.5

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/logger",
-  "version": "7.0.5",
+  "version": "7.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",

--- a/packages/mailer/CHANGELOG.md
+++ b/packages/mailer/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 7.1.0 (2026-06-07)
+
+### 🚀 Features
+
+- add row level security driver ([#236](https://github.com/nest-boot/nest-boot/pull/236))
+
+### 🧱 Updated Dependencies
+
+- Updated @nest-boot/eslint-config to 7.1.0
+- Updated @nest-boot/eslint-plugin to 7.0.8
+- Updated @nest-boot/tsconfig to 7.1.0
+
+### ❤️ Thank You
+
+- Xudong Huang @xudongcc
+
 # @nest-boot/mailer
 
 ## 7.0.3

--- a/packages/mailer/package.json
+++ b/packages/mailer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/mailer",
-  "version": "7.0.3",
+  "version": "7.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",

--- a/packages/metrics/CHANGELOG.md
+++ b/packages/metrics/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 7.1.0 (2026-06-07)
+
+### 🚀 Features
+
+- add row level security driver ([#236](https://github.com/nest-boot/nest-boot/pull/236))
+
+### 🧱 Updated Dependencies
+
+- Updated @nest-boot/eslint-config to 7.1.0
+- Updated @nest-boot/eslint-plugin to 7.0.8
+- Updated @nest-boot/tsconfig to 7.1.0
+
+### ❤️ Thank You
+
+- Xudong Huang @xudongcc
+
 # @nest-boot/metrics
 
 ## 7.0.3

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/metrics",
-  "version": "7.0.3",
+  "version": "7.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",

--- a/packages/middleware/CHANGELOG.md
+++ b/packages/middleware/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 7.4.0 (2026-06-07)
+
+### 🧱 Updated Dependencies
+
+- Updated @nest-boot/eslint-config to 7.1.0
+- Updated @nest-boot/eslint-plugin to 7.0.8
+- Updated @nest-boot/tsconfig to 7.1.0
+
 # @nest-boot/middleware
 
 ## 7.3.0

--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/middleware",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",

--- a/packages/mikro-orm-crypt/CHANGELOG.md
+++ b/packages/mikro-orm-crypt/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 7.3.0 (2026-06-07)
+
+### 🚀 Features
+
+- add row level security driver ([#236](https://github.com/nest-boot/nest-boot/pull/236))
+
+### 🧱 Updated Dependencies
+
+- Updated @nest-boot/eslint-config to 7.1.0
+- Updated @nest-boot/eslint-plugin to 7.0.8
+- Updated @nest-boot/tsconfig to 7.1.0
+- Updated @nest-boot/crypt to 7.2.0
+
+### ❤️ Thank You
+
+- Xudong Huang @xudongcc
+
 # @nest-boot/mikro-orm-crypt
 
 ## 7.2.1

--- a/packages/mikro-orm-crypt/package.json
+++ b/packages/mikro-orm-crypt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/mikro-orm-crypt",
-  "version": "7.2.1",
+  "version": "7.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",

--- a/packages/mikro-orm-hash/CHANGELOG.md
+++ b/packages/mikro-orm-hash/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 7.2.0 (2026-06-07)
+
+### 🚀 Features
+
+- add row level security driver ([#236](https://github.com/nest-boot/nest-boot/pull/236))
+
+### 🧱 Updated Dependencies
+
+- Updated @nest-boot/eslint-config to 7.1.0
+- Updated @nest-boot/eslint-plugin to 7.0.8
+- Updated @nest-boot/tsconfig to 7.1.0
+- Updated @nest-boot/hash to 7.3.0
+
+### ❤️ Thank You
+
+- Xudong Huang @xudongcc
+
 # @nest-boot/mikro-orm-hash
 
 ## 7.1.1

--- a/packages/mikro-orm-hash/package.json
+++ b/packages/mikro-orm-hash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/mikro-orm-hash",
-  "version": "7.1.1",
+  "version": "7.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",

--- a/packages/mikro-orm/CHANGELOG.md
+++ b/packages/mikro-orm/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 7.5.0 (2026-06-07)
+
+### 🚀 Features
+
+- add row level security driver ([#236](https://github.com/nest-boot/nest-boot/pull/236))
+
+### 🧱 Updated Dependencies
+
+- Updated @nest-boot/request-context to 7.5.0
+- Updated @nest-boot/eslint-config to 7.1.0
+- Updated @nest-boot/eslint-plugin to 7.0.8
+- Updated @nest-boot/tsconfig to 7.1.0
+
+### ❤️ Thank You
+
+- Xudong Huang @xudongcc
+
 # @nest-boot/mikro-orm
 
 ## 7.4.0

--- a/packages/mikro-orm/package.json
+++ b/packages/mikro-orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/mikro-orm",
-  "version": "7.4.0",
+  "version": "7.5.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",

--- a/packages/permission/CHANGELOG.md
+++ b/packages/permission/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 7.1.1 (2026-06-07)
+
+### 🧱 Updated Dependencies
+
+- Updated @nest-boot/request-context to 7.5.0
+- Updated @nest-boot/eslint-config to 7.1.0
+- Updated @nest-boot/eslint-plugin to 7.0.8
+- Updated @nest-boot/tsconfig to 7.1.0
+
 # @nest-boot/permission
 
 ## 7.1.0

--- a/packages/permission/package.json
+++ b/packages/permission/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/permission",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",

--- a/packages/redis/CHANGELOG.md
+++ b/packages/redis/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 7.1.0 (2026-06-07)
+
+### 🚀 Features
+
+- add row level security driver ([#236](https://github.com/nest-boot/nest-boot/pull/236))
+
+### 🧱 Updated Dependencies
+
+- Updated @nest-boot/eslint-config to 7.1.0
+- Updated @nest-boot/eslint-plugin to 7.0.8
+- Updated @nest-boot/tsconfig to 7.1.0
+
+### ❤️ Thank You
+
+- Xudong Huang @xudongcc
+
 # @nest-boot/redis
 
 ## 7.0.3

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/redis",
-  "version": "7.0.3",
+  "version": "7.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",

--- a/packages/request-context/CHANGELOG.md
+++ b/packages/request-context/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 7.5.0 (2026-06-07)
+
+### 🚀 Features
+
+- add row level security driver ([#236](https://github.com/nest-boot/nest-boot/pull/236))
+
+### 🧱 Updated Dependencies
+
+- Updated @nest-boot/eslint-config to 7.1.0
+- Updated @nest-boot/eslint-plugin to 7.0.8
+- Updated @nest-boot/middleware to 7.4.0
+- Updated @nest-boot/tsconfig to 7.1.0
+
+### ❤️ Thank You
+
+- Xudong Huang @xudongcc
+
 # @nest-boot/request-context
 
 ## 7.4.3

--- a/packages/request-context/package.json
+++ b/packages/request-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/request-context",
-  "version": "7.4.3",
+  "version": "7.5.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",

--- a/packages/row-level-security/CHANGELOG.md
+++ b/packages/row-level-security/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 7.2.6 (2026-06-07)
+
+### 🧱 Updated Dependencies
+
+- Updated @nest-boot/request-context to 7.5.0
+- Updated @nest-boot/eslint-config to 7.1.0
+- Updated @nest-boot/eslint-plugin to 7.0.8
+- Updated @nest-boot/mikro-orm to 7.5.0
+- Updated @nest-boot/tsconfig to 7.1.0
+
 # @nest-boot/row-level-security
 
 ## 7.2.5

--- a/packages/row-level-security/package.json
+++ b/packages/row-level-security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/row-level-security",
-  "version": "7.2.5",
+  "version": "7.2.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",

--- a/packages/schedule/CHANGELOG.md
+++ b/packages/schedule/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 7.1.0 (2026-06-07)
+
+### 🚀 Features
+
+- add row level security driver ([#236](https://github.com/nest-boot/nest-boot/pull/236))
+
+### 🧱 Updated Dependencies
+
+- Updated @nest-boot/eslint-config to 7.1.0
+- Updated @nest-boot/eslint-plugin to 7.0.8
+- Updated @nest-boot/tsconfig to 7.1.0
+- Updated @nest-boot/bullmq to 7.1.0
+
+### ❤️ Thank You
+
+- Xudong Huang @xudongcc
+
 # @nest-boot/schedule
 
 ## 7.0.3

--- a/packages/schedule/package.json
+++ b/packages/schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/schedule",
-  "version": "7.0.3",
+  "version": "7.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",

--- a/packages/tsconfig/CHANGELOG.md
+++ b/packages/tsconfig/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.1.0 (2026-06-07)
+
+This was a version bump only for @nest-boot/tsconfig to align it with other projects, there were no code changes.
+
 # @nest-boot/tsconfig
 
 ## 7.0.3

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/tsconfig",
-  "version": "7.0.3",
+  "version": "7.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",

--- a/packages/validator/CHANGELOG.md
+++ b/packages/validator/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 7.1.0 (2026-06-07)
+
+### 🚀 Features
+
+- add row level security driver ([#236](https://github.com/nest-boot/nest-boot/pull/236))
+
+### 🧱 Updated Dependencies
+
+- Updated @nest-boot/eslint-config to 7.1.0
+- Updated @nest-boot/eslint-plugin to 7.0.8
+- Updated @nest-boot/tsconfig to 7.1.0
+- Updated @nest-boot/i18n to 7.1.0
+
+### ❤️ Thank You
+
+- Xudong Huang @xudongcc
+
 # @nest-boot/validator
 
 ## 7.0.3

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/validator",
-  "version": "7.0.3",
+  "version": "7.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",

--- a/packages/view/CHANGELOG.md
+++ b/packages/view/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 7.1.0 (2026-06-07)
+
+### 🚀 Features
+
+- add row level security driver ([#236](https://github.com/nest-boot/nest-boot/pull/236))
+
+### 🧱 Updated Dependencies
+
+- Updated @nest-boot/eslint-config to 7.1.0
+- Updated @nest-boot/eslint-plugin to 7.0.8
+- Updated @nest-boot/tsconfig to 7.1.0
+
+### ❤️ Thank You
+
+- Xudong Huang @xudongcc
+
 # @nest-boot/view
 
 ## 7.0.3

--- a/packages/view/package.json
+++ b/packages/view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-boot/view",
-  "version": "7.0.3",
+  "version": "7.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/nest-boot/nest-boot.git",


### PR DESCRIPTION
## Summary
- generated by `pnpm exec nx release --skip-publish`
- bumps independently versioned packages based on conventional commits and dependency updates
- includes `@nest-boot/auth@7.11.1` with the AUTH_*_DISABLE_SIGN_UP env support

## Merge Note
Use a regular merge commit for this PR, not squash, so the release commit remains in master history and the already-created release tags point to a reachable commit.

## Verification
- pnpm exec nx release --skip-publish