### PR TITLE
fix(auth): update auth env defaults

### DIFF
--- a/apps/docs/content/docs/tutorial/auth.mdx
+++ b/apps/docs/content/docs/tutorial/auth.mdx
@@ -41,45 +41,69 @@ The module automatically:
 
 ### Environment Variables
 
-`AuthModule` can configure the default better-auth instance from environment variables. Values passed through `AuthModule.forRoot()` or `AuthModule.forRootAsync()` are merged with these defaults; signup-disable environment variables are preserved when nested auth options are supplied.
+`AuthModule` can configure the default better-auth instance from environment variables. Values passed through `AuthModule.forRoot()` or `AuthModule.forRootAsync()` are merged with these defaults; environment variables can still override nested provider flags where noted below.
 
-| Variable                     | Description                                                                                                                  | Default                              |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| `AUTH_SECRET`                | Auth secret used to sign and encrypt auth data. Falls back to `APP_SECRET`. Must be at least 32 characters and high entropy. | Required                             |
-| `APP_SECRET`                 | Fallback auth secret when `AUTH_SECRET` is not set.                                                                          | Required when `AUTH_SECRET` is unset |
-| `APP_NAME`                   | App name passed to better-auth.                                                                                              | unset                                |
-| `AUTH_URL`                   | Public auth base URL. Falls back to `APP_URL`.                                                                               | unset                                |
-| `APP_URL`                    | Fallback public base URL when `AUTH_URL` is not set.                                                                         | unset                                |
-| `AUTH_EMAIL_ENABLED`         | Set to `true` or `false` to configure email/password auth explicitly.                                                        | better-auth default                  |
-| `AUTH_EMAIL_DISABLE_SIGN_UP` | Set to `true` to disable signup through email/password auth when email/password auth is configured.                          | signup enabled                       |
-| `AUTH_DISABLE_SIGN_UP`       | Set to `true` to disable signup for configured email/password, OIDC, Google, and GitHub auth.                                | signup enabled                       |
+By default, email/password auth is enabled, Google/GitHub/OIDC auth are disabled, and signup is allowed. Set `AUTH_DISABLE_SIGN_UP=true` when you want to stop new signups for every configured method at once.
 
-Google and GitHub are disabled by default. Set `AUTH_GOOGLE_ENABLED=true` or `AUTH_GITHUB_ENABLED=true` to configure the corresponding better-auth `socialProviders.google` or `socialProviders.github` provider from env. In that case, provider credentials are validated at startup:
+#### Common
 
-| Variable                      | Description                                     | Default                                 |
-| ----------------------------- | ----------------------------------------------- | --------------------------------------- |
-| `AUTH_GOOGLE_ENABLED`         | Set to `true` to enable Google auth from env.   | disabled                                |
-| `AUTH_GOOGLE_CLIENT_ID`       | Google OAuth client ID.                         | Required when Google env config is used |
-| `AUTH_GOOGLE_CLIENT_SECRET`   | Google OAuth client secret.                     | Required when Google env config is used |
-| `AUTH_GOOGLE_DISABLE_SIGN_UP` | Set to `true` to disable signup through Google. | signup enabled                          |
-| `AUTH_GITHUB_ENABLED`         | Set to `true` to enable GitHub auth from env.   | disabled                                |
-| `AUTH_GITHUB_CLIENT_ID`       | GitHub OAuth client ID.                         | Required when GitHub env config is used |
-| `AUTH_GITHUB_CLIENT_SECRET`   | GitHub OAuth client secret.                     | Required when GitHub env config is used |
-| `AUTH_GITHUB_DISABLE_SIGN_UP` | Set to `true` to disable signup through GitHub. | signup enabled                          |
+Set these once for the whole auth instance.
 
-Leave `AUTH_GOOGLE_ENABLED` or `AUTH_GITHUB_ENABLED` unset to keep that env provider disabled, even if credentials are present. If you pass `socialProviders.google` or `socialProviders.github` manually, explicit `*_ENABLED=false` and signup-disable env flags are still merged into the nested provider config without requiring credentials to move into env.
+| Variable               | Purpose                                                                                                                 | Default                              |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| `AUTH_SECRET`          | Secret used to sign and encrypt auth data. Falls back to `APP_SECRET`. Must be at least 32 characters and high entropy. | Required                             |
+| `APP_SECRET`           | Fallback secret when `AUTH_SECRET` is not set.                                                                          | Required when `AUTH_SECRET` is unset |
+| `APP_NAME`             | App name passed to better-auth.                                                                                         | unset                                |
+| `AUTH_URL`             | Public auth base URL. Falls back to `APP_URL`.                                                                          | unset                                |
+| `APP_URL`              | Fallback public base URL when `AUTH_URL` is not set.                                                                    | unset                                |
+| `AUTH_DISABLE_SIGN_UP` | Set to `true` to disable signup for every configured auth method. Sign-in still works for existing users.               | signup enabled                       |
 
-Generic OIDC is also disabled by default. Set `AUTH_OIDC_ENABLED=true` to register a `genericOAuth` provider with `providerId: "oidc"`. In that case, the following variables are validated at startup:
+#### Email
 
-| Variable                    | Description                                                                                                                                | Default                               |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------- |
-| `AUTH_OIDC_ENABLED`         | Set to `true` to enable generic OIDC auth from env.                                                                                        | disabled                              |
-| `AUTH_OIDC_CLIENT_ID`       | OIDC client ID.                                                                                                                            | Required when OIDC env config is used |
-| `AUTH_OIDC_CLIENT_SECRET`   | OIDC client secret.                                                                                                                        | Required when OIDC env config is used |
-| `AUTH_OIDC_DISCOVERY_URL`   | OIDC discovery document URL.                                                                                                               | Required when OIDC env config is used |
-| `AUTH_OIDC_PROMPT`          | Optional OIDC prompt. Supported values: `none`, `login`, `create`, `consent`, `select_account`, `select_account consent`, `login consent`. | unset                                 |
-| `AUTH_OIDC_SCOPES`          | Comma-separated OIDC scopes. Whitespace is trimmed and empty entries are ignored.                                                          | `openid,profile,email`                |
-| `AUTH_OIDC_DISABLE_SIGN_UP` | Set to `true` to disable signup through OIDC.                                                                                              | signup enabled                        |
+Email/password auth is on unless you explicitly set `AUTH_EMAIL_ENABLED=false`. To keep email sign-in but block new email signups, set `AUTH_EMAIL_DISABLE_SIGN_UP=true`.
+
+| Variable                     | Purpose                                               | Default        |
+| ---------------------------- | ----------------------------------------------------- | -------------- |
+| `AUTH_EMAIL_ENABLED`         | Enables email/password auth unless set to `false`.    | enabled        |
+| `AUTH_EMAIL_DISABLE_SIGN_UP` | Blocks new email/password signups when set to `true`. | signup enabled |
+
+#### Google
+
+Google auth is off until `AUTH_GOOGLE_ENABLED=true`. When enabled, both Google credentials are required. Leaving `AUTH_GOOGLE_ENABLED` unset keeps Google disabled even if credentials are present.
+
+| Variable                      | Purpose                                          | Default               |
+| ----------------------------- | ------------------------------------------------ | --------------------- |
+| `AUTH_GOOGLE_ENABLED`         | Enables Google auth from env when set to `true`. | disabled              |
+| `AUTH_GOOGLE_CLIENT_ID`       | Google OAuth client ID.                          | Required when enabled |
+| `AUTH_GOOGLE_CLIENT_SECRET`   | Google OAuth client secret.                      | Required when enabled |
+| `AUTH_GOOGLE_DISABLE_SIGN_UP` | Blocks new Google signups when set to `true`.    | signup enabled        |
+
+#### GitHub
+
+GitHub auth is off until `AUTH_GITHUB_ENABLED=true`. When enabled, both GitHub credentials are required. Leaving `AUTH_GITHUB_ENABLED` unset keeps GitHub disabled even if credentials are present.
+
+| Variable                      | Purpose                                          | Default               |
+| ----------------------------- | ------------------------------------------------ | --------------------- |
+| `AUTH_GITHUB_ENABLED`         | Enables GitHub auth from env when set to `true`. | disabled              |
+| `AUTH_GITHUB_CLIENT_ID`       | GitHub OAuth client ID.                          | Required when enabled |
+| `AUTH_GITHUB_CLIENT_SECRET`   | GitHub OAuth client secret.                      | Required when enabled |
+| `AUTH_GITHUB_DISABLE_SIGN_UP` | Blocks new GitHub signups when set to `true`.    | signup enabled        |
+
+If you pass `socialProviders.google` or `socialProviders.github` manually, explicit `*_ENABLED=false` and signup-disable env flags are still merged into the nested provider config without requiring credentials to move into env.
+
+#### OIDC
+
+Generic OIDC is off until `AUTH_OIDC_ENABLED=true`. When enabled, `AuthModule` registers a `genericOAuth` provider with `providerId: "oidc"` and validates the required OIDC settings at startup.
+
+| Variable                    | Purpose                                                                                                                                    | Default                |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------- |
+| `AUTH_OIDC_ENABLED`         | Enables generic OIDC auth from env when set to `true`.                                                                                     | disabled               |
+| `AUTH_OIDC_CLIENT_ID`       | OIDC client ID.                                                                                                                            | Required when enabled  |
+| `AUTH_OIDC_CLIENT_SECRET`   | OIDC client secret.                                                                                                                        | Required when enabled  |
+| `AUTH_OIDC_DISCOVERY_URL`   | OIDC discovery document URL.                                                                                                               | Required when enabled  |
+| `AUTH_OIDC_PROMPT`          | Optional OIDC prompt. Supported values: `none`, `login`, `create`, `consent`, `select_account`, `select_account consent`, `login consent`. | unset                  |
+| `AUTH_OIDC_SCOPES`          | Comma-separated OIDC scopes. Whitespace is trimmed and empty entries are ignored.                                                          | `openid,profile,email` |
+| `AUTH_OIDC_DISABLE_SIGN_UP` | Blocks new OIDC signups when set to `true`.                                                                                                | signup enabled         |
 
 If OIDC is not needed, leave `AUTH_OIDC_ENABLED` unset. If you need multiple generic OIDC providers or custom provider behavior, configure `plugins` manually; `AUTH_OIDC_*` cannot be combined with a custom `genericOAuth` plugin because better-auth registers one shared set of OAuth2 endpoints for that plugin.
 

--- a/apps/docs/content/docs/tutorial/auth.zh-Hans.mdx
+++ b/apps/docs/content/docs/tutorial/auth.zh-Hans.mdx
@@ -41,45 +41,69 @@ const AuthDynamicModule = AuthModule.forRoot({
 
 ### 环境变量
 
-`AuthModule` 可以从环境变量配置默认的 better-auth 实例。通过 `AuthModule.forRoot()` 或 `AuthModule.forRootAsync()` 传入的选项会与这些默认值合并；即使传入了嵌套认证选项，环境变量中的禁用注册开关也会保留。
+`AuthModule` 可以从环境变量配置默认的 better-auth 实例。通过 `AuthModule.forRoot()` 或 `AuthModule.forRootAsync()` 传入的选项会与这些默认值合并；下方特别说明的环境变量仍可以覆盖嵌套 provider 里的开关。
 
-| 变量                         | 说明                                                                                        | 默认值                     |
-| ---------------------------- | ------------------------------------------------------------------------------------------- | -------------------------- |
-| `AUTH_SECRET`                | 用于签名和加密认证数据的密钥。未设置时回退到 `APP_SECRET`。必须至少 32 个字符且具有高熵值。 | 必填                       |
-| `APP_SECRET`                 | 未设置 `AUTH_SECRET` 时使用的备用认证密钥。                                                 | `AUTH_SECRET` 未设置时必填 |
-| `APP_NAME`                   | 传给 better-auth 的应用名称。                                                               | 未设置                     |
-| `AUTH_URL`                   | 公开的认证基础 URL。未设置时回退到 `APP_URL`。                                              | 未设置                     |
-| `APP_URL`                    | 未设置 `AUTH_URL` 时使用的备用公开基础 URL。                                                | 未设置                     |
-| `AUTH_EMAIL_ENABLED`         | 设置为 `true` 或 `false` 时显式配置邮箱密码认证。                                           | better-auth 默认值         |
-| `AUTH_EMAIL_DISABLE_SIGN_UP` | 设置为 `true` 时，在已配置邮箱密码认证的情况下禁用邮箱密码注册。                            | 允许注册                   |
-| `AUTH_DISABLE_SIGN_UP`       | 设置为 `true` 时禁用已配置的邮箱密码、OIDC、Google 和 GitHub 注册。                         | 允许注册                   |
+默认情况下，邮箱密码认证启用，Google、GitHub 和 OIDC 认证禁用，注册允许。需要一次性停止所有已配置登录方式的新用户注册时，设置 `AUTH_DISABLE_SIGN_UP=true`。
 
-Google 和 GitHub 默认禁用。设置 `AUTH_GOOGLE_ENABLED=true` 或 `AUTH_GITHUB_ENABLED=true` 时，`AuthModule` 会从环境变量配置对应的 better-auth `socialProviders.google` 或 `socialProviders.github` 专门 provider。此时模块会在启动时校验 provider 凭据：
+#### 通用
 
-| 变量                          | 说明                                         | 默认值                         |
-| ----------------------------- | -------------------------------------------- | ------------------------------ |
-| `AUTH_GOOGLE_ENABLED`         | 设置为 `true` 时从环境变量启用 Google 认证。 | 禁用                           |
-| `AUTH_GOOGLE_CLIENT_ID`       | Google OAuth 客户端 ID。                     | 使用 Google 环境变量配置时必填 |
-| `AUTH_GOOGLE_CLIENT_SECRET`   | Google OAuth 客户端密钥。                    | 使用 Google 环境变量配置时必填 |
-| `AUTH_GOOGLE_DISABLE_SIGN_UP` | 设置为 `true` 时禁用 Google 注册。           | 允许注册                       |
-| `AUTH_GITHUB_ENABLED`         | 设置为 `true` 时从环境变量启用 GitHub 认证。 | 禁用                           |
-| `AUTH_GITHUB_CLIENT_ID`       | GitHub OAuth 客户端 ID。                     | 使用 GitHub 环境变量配置时必填 |
-| `AUTH_GITHUB_CLIENT_SECRET`   | GitHub OAuth 客户端密钥。                    | 使用 GitHub 环境变量配置时必填 |
-| `AUTH_GITHUB_DISABLE_SIGN_UP` | 设置为 `true` 时禁用 GitHub 注册。           | 允许注册                       |
+这些变量作用于整个 auth 实例。
 
-如果不需要某个 env provider，保持 `AUTH_GOOGLE_ENABLED` 或 `AUTH_GITHUB_ENABLED` 未设置即可；即使设置了凭据，也不会启用。如果手动传入了 `socialProviders.google` 或 `socialProviders.github`，显式的 `*_ENABLED=false` 和禁用注册相关环境变量仍会合并到对应的嵌套 provider 配置中，不需要把凭据也移动到环境变量里。
+| 变量                   | 用途                                                                                        | 默认值                     |
+| ---------------------- | ------------------------------------------------------------------------------------------- | -------------------------- |
+| `AUTH_SECRET`          | 用于签名和加密认证数据的密钥。未设置时回退到 `APP_SECRET`。必须至少 32 个字符且具有高熵值。 | 必填                       |
+| `APP_SECRET`           | 未设置 `AUTH_SECRET` 时使用的备用认证密钥。                                                 | `AUTH_SECRET` 未设置时必填 |
+| `APP_NAME`             | 传给 better-auth 的应用名称。                                                               | 未设置                     |
+| `AUTH_URL`             | 公开的认证基础 URL。未设置时回退到 `APP_URL`。                                              | 未设置                     |
+| `APP_URL`              | 未设置 `AUTH_URL` 时使用的备用公开基础 URL。                                                | 未设置                     |
+| `AUTH_DISABLE_SIGN_UP` | 设置为 `true` 时，禁止所有已配置登录方式的新用户注册。已有用户仍可登录。                    | 允许注册                   |
 
-Generic OIDC 也默认禁用。设置 `AUTH_OIDC_ENABLED=true` 时，`AuthModule` 会注册一个 `providerId: "oidc"` 的 `genericOAuth` 提供商。此时模块会在启动时校验以下变量：
+#### Email
 
-| 变量                        | 说明                                                                                                                            | 默认值                       |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
-| `AUTH_OIDC_ENABLED`         | 设置为 `true` 时从环境变量启用 generic OIDC 认证。                                                                              | 禁用                         |
-| `AUTH_OIDC_CLIENT_ID`       | OIDC 客户端 ID。                                                                                                                | 使用 OIDC 环境变量配置时必填 |
-| `AUTH_OIDC_CLIENT_SECRET`   | OIDC 客户端密钥。                                                                                                               | 使用 OIDC 环境变量配置时必填 |
-| `AUTH_OIDC_DISCOVERY_URL`   | OIDC discovery 文档 URL。                                                                                                       | 使用 OIDC 环境变量配置时必填 |
-| `AUTH_OIDC_PROMPT`          | 可选的 OIDC prompt。支持值：`none`、`login`、`create`、`consent`、`select_account`、`select_account consent`、`login consent`。 | 未设置                       |
-| `AUTH_OIDC_SCOPES`          | 逗号分隔的 OIDC scopes。会 trim 空白并忽略空项。                                                                                | `openid,profile,email`       |
-| `AUTH_OIDC_DISABLE_SIGN_UP` | 设置为 `true` 时禁用 OIDC 注册。                                                                                                | 允许注册                     |
+邮箱密码认证默认启用。设置 `AUTH_EMAIL_ENABLED=false` 时才会关闭邮箱密码认证。想保留邮箱登录但禁止新用户用邮箱注册时，设置 `AUTH_EMAIL_DISABLE_SIGN_UP=true`。
+
+| 变量                         | 用途                                       | 默认值   |
+| ---------------------------- | ------------------------------------------ | -------- |
+| `AUTH_EMAIL_ENABLED`         | 除非设置为 `false`，否则启用邮箱密码认证。 | 启用     |
+| `AUTH_EMAIL_DISABLE_SIGN_UP` | 设置为 `true` 时禁止新的邮箱密码注册。     | 允许注册 |
+
+#### Google
+
+Google 认证默认禁用。设置 `AUTH_GOOGLE_ENABLED=true` 后，模块会从环境变量配置 better-auth `socialProviders.google`，并在启动时校验 Google 凭据。即使配置了凭据，只要没有设置 `AUTH_GOOGLE_ENABLED=true`，Google 仍保持禁用。
+
+| 变量                          | 用途                                         | 默认值     |
+| ----------------------------- | -------------------------------------------- | ---------- |
+| `AUTH_GOOGLE_ENABLED`         | 设置为 `true` 时从环境变量启用 Google 认证。 | 禁用       |
+| `AUTH_GOOGLE_CLIENT_ID`       | Google OAuth 客户端 ID。                     | 启用时必填 |
+| `AUTH_GOOGLE_CLIENT_SECRET`   | Google OAuth 客户端密钥。                    | 启用时必填 |
+| `AUTH_GOOGLE_DISABLE_SIGN_UP` | 设置为 `true` 时禁止新的 Google 注册。       | 允许注册   |
+
+#### GitHub
+
+GitHub 认证默认禁用。设置 `AUTH_GITHUB_ENABLED=true` 后，模块会从环境变量配置 better-auth `socialProviders.github`，并在启动时校验 GitHub 凭据。即使配置了凭据，只要没有设置 `AUTH_GITHUB_ENABLED=true`，GitHub 仍保持禁用。
+
+| 变量                          | 用途                                         | 默认值     |
+| ----------------------------- | -------------------------------------------- | ---------- |
+| `AUTH_GITHUB_ENABLED`         | 设置为 `true` 时从环境变量启用 GitHub 认证。 | 禁用       |
+| `AUTH_GITHUB_CLIENT_ID`       | GitHub OAuth 客户端 ID。                     | 启用时必填 |
+| `AUTH_GITHUB_CLIENT_SECRET`   | GitHub OAuth 客户端密钥。                    | 启用时必填 |
+| `AUTH_GITHUB_DISABLE_SIGN_UP` | 设置为 `true` 时禁止新的 GitHub 注册。       | 允许注册   |
+
+如果手动传入了 `socialProviders.google` 或 `socialProviders.github`，显式的 `*_ENABLED=false` 和禁用注册相关环境变量仍会合并到对应的嵌套 provider 配置中，不需要把凭据也移动到环境变量里。
+
+#### OIDC
+
+Generic OIDC 默认禁用。设置 `AUTH_OIDC_ENABLED=true` 后，模块会注册一个 `providerId: "oidc"` 的 `genericOAuth` provider，并在启动时校验 OIDC 必需配置。
+
+| 变量                        | 用途                                                                                                                            | 默认值                 |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| `AUTH_OIDC_ENABLED`         | 设置为 `true` 时从环境变量启用 generic OIDC 认证。                                                                              | 禁用                   |
+| `AUTH_OIDC_CLIENT_ID`       | OIDC 客户端 ID。                                                                                                                | 启用时必填             |
+| `AUTH_OIDC_CLIENT_SECRET`   | OIDC 客户端密钥。                                                                                                               | 启用时必填             |
+| `AUTH_OIDC_DISCOVERY_URL`   | OIDC discovery 文档 URL。                                                                                                       | 启用时必填             |
+| `AUTH_OIDC_PROMPT`          | 可选的 OIDC prompt。支持值：`none`、`login`、`create`、`consent`、`select_account`、`select_account consent`、`login consent`。 | 未设置                 |
+| `AUTH_OIDC_SCOPES`          | 逗号分隔的 OIDC scopes。会 trim 空白并忽略空项。                                                                                | `openid,profile,email` |
+| `AUTH_OIDC_DISABLE_SIGN_UP` | 设置为 `true` 时禁止新的 OIDC 注册。                                                                                            | 允许注册               |
 
 如果不需要 OIDC，保持 `AUTH_OIDC_ENABLED` 未设置即可。如果需要多个 generic OIDC provider 或自定义 provider 行为，可以手动配置 `plugins`；`AUTH_OIDC_*` 不能和自定义 `genericOAuth` 插件组合使用，因为 better-auth 会为该插件注册同一组 OAuth2 endpoints。
 

--- a/packages/auth/src/auth.module.spec.ts
+++ b/packages/auth/src/auth.module.spec.ts
@@ -255,9 +255,32 @@ describe("AuthModule", () => {
     );
   });
 
-  it("should disable email and OIDC signup when the global signup disable flag is enabled", () => {
+  it("should enable email auth by default when AUTH_EMAIL_ENABLED is unset", () => {
+    const orm = {
+      em: {},
+    } as unknown as MikroORM;
+    const authProvider = getAuthProvider();
+
+    authProvider.useFactory(
+      {
+        entities,
+        secret,
+      },
+      orm,
+    );
+
+    expect(mockBetterAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailAndPassword: {
+          disableSignUp: false,
+          enabled: true,
+        },
+      }),
+    );
+  });
+
+  it("should disable email, OIDC, and social signup when the global signup disable flag is enabled", () => {
     process.env.AUTH_DISABLE_SIGN_UP = "true";
-    process.env.AUTH_EMAIL_ENABLED = "true";
     setGithubEnv();
     setGoogleEnv();
     setOidcEnv();
@@ -623,8 +646,8 @@ describe("AuthModule", () => {
     ).toThrow("AUTH_OIDC_*");
   });
 
-  it("should merge email auth options without dropping env signup disable flags", () => {
-    process.env.AUTH_DISABLE_SIGN_UP = "true";
+  it("should merge email auth options without dropping email signup disable env flags", () => {
+    process.env.AUTH_EMAIL_DISABLE_SIGN_UP = "true";
     const orm = {
       em: {},
     } as unknown as MikroORM;

--- a/packages/auth/src/auth.module.ts
+++ b/packages/auth/src/auth.module.ts
@@ -74,9 +74,7 @@ import { resolveSecret } from "./utils/resolve-secret";
             skipStateCookieCheck: true,
           },
           ...betterAuthOptions,
-          ...(emailAndPasswordConfig
-            ? { emailAndPassword: emailAndPasswordConfig }
-            : {}),
+          emailAndPassword: emailAndPasswordConfig,
           ...(socialProvidersConfig
             ? { socialProviders: socialProvidersConfig }
             : {}),

--- a/packages/auth/src/utils/create-email-and-password-config.spec.ts
+++ b/packages/auth/src/utils/create-email-and-password-config.spec.ts
@@ -2,12 +2,16 @@ import { createEmailAndPasswordConfig } from "./create-email-and-password-config
 
 describe("createEmailAndPasswordConfig", () => {
   beforeEach(() => {
+    delete process.env.AUTH_DISABLE_SIGN_UP;
     delete process.env.AUTH_EMAIL_DISABLE_SIGN_UP;
     delete process.env.AUTH_EMAIL_ENABLED;
   });
 
-  it("should preserve better-auth defaults when email auth is not configured", () => {
-    expect(createEmailAndPasswordConfig(false)).toBeUndefined();
+  it("should enable email auth when AUTH_EMAIL_ENABLED is unset", () => {
+    expect(createEmailAndPasswordConfig(false)).toEqual({
+      disableSignUp: false,
+      enabled: true,
+    });
   });
 
   it("should enable email auth when AUTH_EMAIL_ENABLED is true", () => {
@@ -28,14 +32,17 @@ describe("createEmailAndPasswordConfig", () => {
     });
   });
 
-  it("should not create email auth config for signup disable flags alone", () => {
+  it("should disable signup when AUTH_EMAIL_DISABLE_SIGN_UP is true and AUTH_EMAIL_ENABLED is unset", () => {
     process.env.AUTH_EMAIL_DISABLE_SIGN_UP = "true";
 
-    expect(createEmailAndPasswordConfig(true)).toBeUndefined();
+    expect(createEmailAndPasswordConfig(false)).toEqual({
+      disableSignUp: true,
+      enabled: true,
+    });
   });
 
-  it("should disable signup when the global disable flag is true and email auth is configured", () => {
-    process.env.AUTH_EMAIL_ENABLED = "true";
+  it("should disable signup when the global disable flag is true and AUTH_EMAIL_ENABLED is unset", () => {
+    process.env.AUTH_DISABLE_SIGN_UP = "true";
 
     expect(createEmailAndPasswordConfig(true)).toEqual({
       disableSignUp: true,
@@ -77,6 +84,17 @@ describe("createEmailAndPasswordConfig", () => {
     ).toEqual({
       disableSignUp: true,
       enabled: true,
+    });
+  });
+
+  it("should preserve explicit email auth enabled options when AUTH_EMAIL_ENABLED is unset", () => {
+    expect(
+      createEmailAndPasswordConfig(false, {
+        enabled: false,
+      }),
+    ).toEqual({
+      disableSignUp: false,
+      enabled: false,
     });
   });
 });

--- a/packages/auth/src/utils/create-email-and-password-config.ts
+++ b/packages/auth/src/utils/create-email-and-password-config.ts
@@ -8,22 +8,17 @@ type EmailAndPasswordConfig = NonNullable<
 export function createEmailAndPasswordConfig(
   disableSignUp: boolean,
   options?: EmailAndPasswordConfig,
-): EmailAndPasswordConfig | undefined {
+): EmailAndPasswordConfig {
   const hasEnabledEnv = process.env.AUTH_EMAIL_ENABLED !== undefined;
   const shouldDisableSignUp =
     disableSignUp || isEnvTrue("AUTH_EMAIL_DISABLE_SIGN_UP");
-
-  if (!options && !hasEnabledEnv) {
-    return undefined;
-  }
+  const enabled = hasEnabledEnv
+    ? process.env.AUTH_EMAIL_ENABLED !== "false"
+    : (options?.enabled ?? true);
 
   return {
-    ...(options ?? {
-      enabled: process.env.AUTH_EMAIL_ENABLED !== "false",
-    }),
-    ...(hasEnabledEnv
-      ? { enabled: process.env.AUTH_EMAIL_ENABLED !== "false" }
-      : {}),
+    ...options,
+    enabled,
     disableSignUp: shouldDisableSignUp || options?.disableSignUp === true,
   };
 }


### PR DESCRIPTION
## Summary

- enable email/password auth by default when `AUTH_EMAIL_ENABLED` is unset
- keep Google, GitHub, and OIDC disabled by default until their `AUTH_*_ENABLED` flags are set to `true`
- document auth environment variables by Common, Email, Google, GitHub, and OIDC groups with more human-readable guidance

## Impact

Email/password auth now gets an explicit default config of `enabled: true` unless `AUTH_EMAIL_ENABLED=false` or user options override it. Global and provider-specific signup-disable flags continue to control registration separately.

## Validation

- `pnpm --filter @nest-boot/auth exec jest --runInBand`
- `pnpm --filter @nest-boot/auth build`
- `pnpm --filter @nest-boot/auth lint`
- `pnpm --filter @nest-boot/docs types:check`
- `git diff --check`
- commit hook: `lint-staged && pnpm docs:check`