### PR TITLE
fix(ci): run full nx release

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -121,6 +121,6 @@ jobs:
 
       - name: Release packages
         if: inputs.release
-        run: pnpm exec nx release publish --yes
+        run: pnpm exec nx release --yes
         env:
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary

- Change the release workflow from `nx release publish --yes` to `nx release --yes`.
- Keep npm provenance enabled for the publish step.

## Why

The previous workflow only attempted to publish already-versioned packages. After `533362c`, `@nest-boot/auth` was still `7.11.1`, so CI skipped publishing because that version already existed on npm. Running the full Nx release command lets Nx calculate the next version, generate changelog/release metadata, tag, and publish.

## Validation

- `git diff --check`
- `pnpm exec nx release --dry-run --skip-publish`
- Commit hook: `pnpm docs:check` via `commit:check`