### PR TITLE
feat: support fulltext field mapping in graphql connection

### DIFF
--- a/apps/docs/content/docs/tutorial/graphql-connection.mdx
+++ b/apps/docs/content/docs/tutorial/graphql-connection.mdx
@@ -61,7 +61,36 @@ Supports both forward (`first`/`after`) and backward (`last`/`before`) paginatio
 
 ## Filtering
 
-MongoDB-style filter syntax with operators: `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, `$nin`, `$and`, `$or`, `$regex`.
+MongoDB-style filter syntax with operators: `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, `$nin`, `$and`, `$or`, `$not`, `$fulltext`, `$prefix`, `$contains`, and `$overlap`.
+
+String fields can map full-text filters to a dedicated MikroORM full-text property:
+
+```typescript
+import { Entity, Index, Property } from "@mikro-orm/core";
+import { FullTextType } from "@mikro-orm/postgresql";
+
+@Entity()
+class Book {
+  @Property()
+  title!: string;
+
+  @Index({ type: "fulltext" })
+  @Property({ type: FullTextType, onUpdate: (book) => book.title })
+  searchableTitle!: string;
+}
+
+export const { Connection: BookConnection } = new ConnectionBuilder(Book)
+  .addField({
+    field: "title",
+    type: "string",
+    filterable: true,
+    searchable: true,
+    fulltext: "searchableTitle",
+  })
+  .build();
+```
+
+With that configuration, `filter: { title: { $fulltext: "nest" } }` and `query: "title:nest"` both search `searchableTitle`, while regular operators such as `$eq` still target `title`.
 
 ## Search Query
 

--- a/apps/docs/content/docs/tutorial/graphql-connection.zh-Hans.mdx
+++ b/apps/docs/content/docs/tutorial/graphql-connection.zh-Hans.mdx
@@ -33,6 +33,39 @@ export const {
   .build();
 ```
 
+## 过滤
+
+支持 MongoDB 风格过滤操作符：`$eq`、`$ne`、`$gt`、`$gte`、`$lt`、`$lte`、`$in`、`$nin`、`$and`、`$or`、`$not`、`$fulltext`、`$prefix`、`$contains` 和 `$overlap`。
+
+字符串字段可以把全文检索映射到专门的 MikroORM 全文检索属性：
+
+```typescript
+import { Entity, Index, Property } from "@mikro-orm/core";
+import { FullTextType } from "@mikro-orm/postgresql";
+
+@Entity()
+class Book {
+  @Property()
+  title!: string;
+
+  @Index({ type: "fulltext" })
+  @Property({ type: FullTextType, onUpdate: (book) => book.title })
+  searchableTitle!: string;
+}
+
+export const { Connection: BookConnection } = new ConnectionBuilder(Book)
+  .addField({
+    field: "title",
+    type: "string",
+    filterable: true,
+    searchable: true,
+    fulltext: "searchableTitle",
+  })
+  .build();
+```
+
+这样配置后，`filter: { title: { $fulltext: "nest" } }` 和 `query: "title:nest"` 都会查询 `searchableTitle`；`$eq` 等普通操作符仍然查询 `title`。
+
 ## 特性
 
 - **Relay 兼容** - 遵循 Relay 连接规范

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -21,7 +21,8 @@
     "next": "16.1.6",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "ts-node": "^10.9.2",
     "typedoc": "^0.28.17",
     "typedoc-plugin-frontmatter": "^1.3.1",
-    "typedoc-plugin-markdown": "^4.10.0"
+    "typedoc-plugin-markdown": "^4.10.0",
+    "zod": "^4.3.6"
   },
   "lint-staged": {
     "*.{md,json}": [
@@ -61,6 +62,11 @@
   "config": {
     "commitizen": {
       "path": "cz-conventional-changelog"
+    }
+  },
+  "pnpm": {
+    "overrides": {
+      "zod": "4.3.6"
     }
   },
   "volta": {

--- a/packages/graphql-connection/jest.config.ts
+++ b/packages/graphql-connection/jest.config.ts
@@ -6,6 +6,9 @@ export default {
   transform: {
     "^.+.(t|j)s$": "ts-jest",
   },
+  moduleNameMapper: {
+    "^lodash-es/(.*)\\.js$": "lodash/$1",
+  },
   coverageDirectory: "./coverage",
   collectCoverageFrom: ["src/**/*"],
   testEnvironment: "node",

--- a/packages/graphql-connection/package.json
+++ b/packages/graphql-connection/package.json
@@ -32,9 +32,9 @@
   "dependencies": {
     "inflection": "^3.0.2",
     "lodash": "^4.17.21",
-    "mikro-orm-filter-query-schema": "^1.2.0",
+    "mikro-orm-filter-query-schema": "^1.3.0",
     "search-syntax": "^3.7.0",
-    "zod": "^4.1.13"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@mikro-orm/core": "^6.6.2",

--- a/packages/graphql-connection/src/connection-query-builder.spec.ts
+++ b/packages/graphql-connection/src/connection-query-builder.spec.ts
@@ -1,0 +1,74 @@
+import "reflect-metadata";
+
+import type { EntityManager } from "@mikro-orm/core";
+
+import { ConnectionQueryBuilder } from "./connection-query-builder";
+import { GRAPHQL_CONNECTION_METADATA } from "./graphql-connection.constants";
+import type {
+  ConnectionFieldOptions,
+  ConnectionMetadata,
+  FieldOptions,
+} from "./interfaces";
+import type { ConnectionClass } from "./types";
+import { createFilter } from "./utils";
+
+interface Book {
+  id: number;
+  title: string;
+  searchableTitle: string;
+}
+
+class BookEntity implements Book {
+  id!: number;
+
+  title!: string;
+
+  searchableTitle!: string;
+}
+
+class BookConnection {}
+
+describe("ConnectionQueryBuilder", () => {
+  it("maps query string fulltext searches to a configured fulltext field path", async () => {
+    const titleField = {
+      field: "title",
+      type: "string",
+      filterable: true,
+      searchable: true,
+      fulltext: "searchableTitle",
+    } satisfies FieldOptions<Book, "string", "searchableTitle">;
+    const fieldOptionsMap = new Map<string, ConnectionFieldOptions<Book>>([
+      ["title", titleField],
+    ]);
+    const { filterQuerySchema } = createFilter("Book", fieldOptionsMap);
+
+    Reflect.defineMetadata(
+      GRAPHQL_CONNECTION_METADATA,
+      {
+        entityClass: BookEntity,
+        fieldOptionsMap,
+        filterQuerySchema,
+      } satisfies ConnectionMetadata<Book>,
+      BookConnection,
+    );
+
+    const find = jest.fn().mockResolvedValue([]);
+    const entityManager = {
+      find,
+      findAll: jest.fn().mockResolvedValue([]),
+    } as unknown as EntityManager;
+
+    await new ConnectionQueryBuilder(
+      entityManager,
+      BookConnection as unknown as ConnectionClass<Book>,
+      { first: 10, query: "title:search" },
+    ).query();
+
+    expect(find).toHaveBeenNthCalledWith(
+      1,
+      BookEntity,
+      { searchableTitle: { $fulltext: "search" } },
+      expect.objectContaining({ limit: 11 }),
+    );
+  });
+});

--- a/packages/graphql-connection/src/connection-query-builder.spec.ts
+++ b/packages/graphql-connection/src/connection-query-builder.spec.ts
@@ -1,8 +1,10 @@
 import "reflect-metadata";
 
-import type { EntityManager } from "@mikro-orm/core";
+import { type EntityManager, QueryOrder } from "@mikro-orm/core";
 
 import { ConnectionQueryBuilder } from "./connection-query-builder";
+import { Cursor } from "./cursor";
+import { OrderDirection } from "./enums";
 import { GRAPHQL_CONNECTION_METADATA } from "./graphql-connection.constants";
 import type {
   ConnectionFieldOptions,
@@ -15,6 +17,7 @@ import { createFilter } from "./utils";
 interface Book {
   id: number;
   title: string;
+  isbn: string;
   searchableTitle: string;
 }
 
@@ -23,40 +26,63 @@ class BookEntity implements Book {
 
   title!: string;
 
+  isbn!: string;
+
   searchableTitle!: string;
 }
 
 class BookConnection {}
 
+function createFieldOptionsMap() {
+  const titleField = {
+    field: "title",
+    type: "string",
+    filterable: true,
+    sortable: true,
+    searchable: true,
+    fulltext: "searchableTitle",
+  } satisfies FieldOptions<Book, "string", "searchableTitle">;
+
+  return new Map<string, ConnectionFieldOptions<Book>>([["title", titleField]]);
+}
+
+function setConnectionMetadata(
+  fieldOptionsMap: Map<
+    string,
+    ConnectionFieldOptions<Book>
+  > = createFieldOptionsMap(),
+) {
+  const { filterQuerySchema } = createFilter("Book", fieldOptionsMap);
+
+  Reflect.defineMetadata(
+    GRAPHQL_CONNECTION_METADATA,
+    {
+      entityClass: BookEntity,
+      fieldOptionsMap,
+      filterQuerySchema,
+    } satisfies ConnectionMetadata<Book>,
+    BookConnection,
+  );
+}
+
+function createEntityManager(entities: Book[] = []) {
+  const find = jest.fn().mockResolvedValue(entities);
+  const findAll = jest.fn().mockResolvedValue(entities);
+
+  return {
+    entityManager: { find, findAll } as unknown as EntityManager,
+    find,
+    findAll,
+  };
+}
+
 describe("ConnectionQueryBuilder", () => {
+  beforeEach(() => {
+    setConnectionMetadata();
+  });
+
   it("maps query string fulltext searches to a configured fulltext field path", async () => {
-    const titleField = {
-      field: "title",
-      type: "string",
-      filterable: true,
-      searchable: true,
-      fulltext: "searchableTitle",
-    } satisfies FieldOptions<Book, "string", "searchableTitle">;
-    const fieldOptionsMap = new Map<string, ConnectionFieldOptions<Book>>([
-      ["title", titleField],
-    ]);
-    const { filterQuerySchema } = createFilter("Book", fieldOptionsMap);
-
-    Reflect.defineMetadata(
-      GRAPHQL_CONNECTION_METADATA,
-      {
-        entityClass: BookEntity,
-        fieldOptionsMap,
-        filterQuerySchema,
-      } satisfies ConnectionMetadata<Book>,
-      BookConnection,
-    );
-
-    const find = jest.fn().mockResolvedValue([]);
-    const entityManager = {
-      find,
-      findAll: jest.fn().mockResolvedValue([]),
-    } as unknown as EntityManager;
+    const { entityManager, find } = createEntityManager();
 
     await new ConnectionQueryBuilder(
       entityManager,
@@ -70,5 +96,200 @@ describe("ConnectionQueryBuilder", () => {
       { searchableTitle: { $fulltext: "search" } },
       expect.objectContaining({ limit: 11 }),
     );
+  });
+
+  it("keeps query string searches on fields without fulltext enabled", async () => {
+    const fieldOptionsMap = createFieldOptionsMap();
+    const isbnField = {
+      field: "isbn",
+      type: "string",
+      filterable: true,
+    } satisfies FieldOptions<Book, "string", "isbn">;
+    fieldOptionsMap.set("isbn", isbnField);
+    setConnectionMetadata(fieldOptionsMap);
+    const { entityManager, find } = createEntityManager();
+
+    await new ConnectionQueryBuilder(
+      entityManager,
+      BookConnection as unknown as ConnectionClass<Book>,
+      { first: 10, query: "isbn:978" },
+    ).query();
+
+    expect(find).toHaveBeenNthCalledWith(
+      1,
+      BookEntity,
+      { isbn: "978" },
+      expect.objectContaining({ limit: 11 }),
+    );
+  });
+
+  it("uses findAll when no filter inputs are present", async () => {
+    const rows = [
+      { id: 1, title: "A", isbn: "1", searchableTitle: "A" },
+      { id: 2, title: "B", isbn: "2", searchableTitle: "B" },
+    ];
+    const { entityManager, find, findAll } = createEntityManager(rows);
+
+    const result = await new ConnectionQueryBuilder(
+      entityManager,
+      BookConnection as unknown as ConnectionClass<Book>,
+      { first: 2, query: "   " },
+    ).query();
+
+    expect(find).not.toHaveBeenCalled();
+    expect(findAll).toHaveBeenNthCalledWith(
+      1,
+      BookEntity,
+      expect.objectContaining({
+        limit: 3,
+        orderBy: [{ id: QueryOrder.ASC }],
+      }),
+    );
+    expect(findAll).toHaveBeenNthCalledWith(2, BookEntity, {
+      fields: ["id"],
+      limit: 10000,
+      disableIdentityMap: true,
+    });
+    expect(result).toEqual({
+      totalCount: 2,
+      edges: expect.arrayContaining([
+        expect.objectContaining({ node: rows[0] }),
+        expect.objectContaining({ node: rows[1] }),
+      ]),
+      pageInfo: {
+        hasNextPage: false,
+        hasPreviousPage: false,
+        startCursor: expect.any(String),
+        endCursor: expect.any(String),
+      },
+    });
+  });
+
+  it("applies forward cursor filters for ordered queries", async () => {
+    const rows = [
+      { id: 2, title: "B", isbn: "2", searchableTitle: "B" },
+      { id: 3, title: "C", isbn: "3", searchableTitle: "C" },
+      { id: 4, title: "D", isbn: "4", searchableTitle: "D" },
+    ];
+    const { entityManager, find } = createEntityManager(rows);
+    const after = new Cursor({ id: 1, value: "A" }).toString();
+
+    const result = await new ConnectionQueryBuilder(
+      entityManager,
+      BookConnection as unknown as ConnectionClass<Book>,
+      {
+        first: 2,
+        after,
+        orderBy: {
+          field: "title" as never,
+          direction: OrderDirection.ASC,
+        },
+      },
+    ).query();
+
+    expect(find).toHaveBeenNthCalledWith(
+      1,
+      BookEntity,
+      {
+        $or: [
+          { title: { $gt: "A" } },
+          {
+            $and: [{ title: { $eq: "A" } }, { id: { $gt: 1 } }],
+          },
+        ],
+      },
+      expect.objectContaining({
+        limit: 3,
+        orderBy: [{ title: QueryOrder.ASC }, { id: QueryOrder.ASC }],
+      }),
+    );
+    expect(result.edges).toHaveLength(2);
+    expect(result.pageInfo.hasNextPage).toBe(true);
+    expect(result.pageInfo.hasPreviousPage).toBe(true);
+    expect(new Cursor(result.edges[0].cursor).value).toBe("B");
+  });
+
+  it("applies backward cursor filters and reverses returned entities", async () => {
+    const rows = [
+      { id: 4, title: "D", isbn: "4", searchableTitle: "D" },
+      { id: 3, title: "C", isbn: "3", searchableTitle: "C" },
+      { id: 2, title: "B", isbn: "2", searchableTitle: "B" },
+    ];
+    const { entityManager, find } = createEntityManager(rows);
+    const before = new Cursor({ id: 5, value: "E" }).toString();
+
+    const result = await new ConnectionQueryBuilder(
+      entityManager,
+      BookConnection as unknown as ConnectionClass<Book>,
+      {
+        last: 2,
+        before,
+        orderBy: {
+          field: "title" as never,
+          direction: OrderDirection.ASC,
+        },
+      },
+    ).query();
+
+    expect(find).toHaveBeenNthCalledWith(
+      1,
+      BookEntity,
+      {
+        $or: [
+          { title: { $lt: "E" } },
+          {
+            $and: [{ title: { $eq: "E" } }, { id: { $lt: 5 } }],
+          },
+        ],
+      },
+      expect.objectContaining({
+        limit: 3,
+        orderBy: [{ title: QueryOrder.DESC }, { id: QueryOrder.DESC }],
+      }),
+    );
+    expect(result.edges.map((edge) => edge.node.id)).toEqual([3, 4]);
+    expect(result.pageInfo.hasNextPage).toBe(true);
+    expect(result.pageInfo.hasPreviousPage).toBe(true);
+  });
+
+  it("rejects ambiguous pagination arguments", () => {
+    const { entityManager } = createEntityManager();
+
+    expect(
+      () =>
+        new ConnectionQueryBuilder(
+          entityManager,
+          BookConnection as unknown as ConnectionClass<Book>,
+          {
+            first: 1,
+            before: new Cursor({ id: 1 }).toString(),
+          },
+        ),
+    ).toThrow("paging must use either first/after or last/before");
+
+    expect(
+      () =>
+        new ConnectionQueryBuilder(
+          entityManager,
+          BookConnection as unknown as ConnectionClass<Book>,
+          {
+            first: 1,
+            last: 1,
+          },
+        ),
+    ).toThrow("cursor-based pagination cannot be forwards AND backwards");
+  });
+
+  it("requires connection metadata", () => {
+    class MissingMetadataConnection {}
+
+    expect(
+      () =>
+        new ConnectionQueryBuilder(
+          createEntityManager().entityManager,
+          MissingMetadataConnection as unknown as ConnectionClass<Book>,
+          { first: 1 },
+        ),
+    ).toThrow("Connection metadata not found");
   });
 });

--- a/packages/graphql-connection/src/connection-query-builder.ts
+++ b/packages/graphql-connection/src/connection-query-builder.ts
@@ -257,7 +257,9 @@ export class ConnectionQueryBuilder<
             type: options.type,
             array: options.array,
             searchable: options.searchable,
-            ...("fulltext" in options ? { fulltext: options.fulltext } : {}),
+            ...("fulltext" in options
+              ? { fulltext: Boolean(options.fulltext) }
+              : {}),
             ...("prefix" in options ? { prefix: options.prefix } : {}),
           };
         }

--- a/packages/graphql-connection/src/connection.builder.spec.ts
+++ b/packages/graphql-connection/src/connection.builder.spec.ts
@@ -1,0 +1,177 @@
+import "reflect-metadata";
+
+import { LazyMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/lazy-metadata.storage";
+import { TypeMetadataStorage } from "@nestjs/graphql/dist/schema-builder/storages/type-metadata.storage";
+import { Kind } from "graphql";
+
+import { ConnectionBuilder } from "./connection.builder";
+import { GRAPHQL_CONNECTION_METADATA } from "./graphql-connection.constants";
+import type { ConnectionMetadata } from "./interfaces";
+import { PageInfo } from "./objects";
+
+interface BuilderBook {
+  id: number;
+  title: string;
+  searchableTitle: string;
+  author: {
+    name: string;
+  };
+  publishedAt: Date;
+}
+
+class BuilderBookEntity implements BuilderBook {
+  id!: number;
+
+  title!: string;
+
+  searchableTitle!: string;
+
+  author!: { name: string };
+
+  publishedAt!: Date;
+}
+
+function fieldNamesAndInvokeTypeFns(
+  metadata:
+    | { properties?: { name: string; typeFn?: () => unknown }[] }
+    | undefined,
+) {
+  expect(metadata).toBeDefined();
+
+  return metadata?.properties?.map((field) => {
+    field.typeFn?.();
+    return field.name;
+  });
+}
+
+describe("ConnectionBuilder", () => {
+  it("builds connection types with ordering metadata and filter parsing", () => {
+    const result = new ConnectionBuilder(BuilderBookEntity, {
+      filter: {
+        maxDepth: 2,
+        maxConditions: 20,
+        maxOrBranches: 5,
+        maxArrayLength: 100,
+      },
+    })
+      .addField({
+        field: "title",
+        type: "string",
+        filterable: true,
+        sortable: true,
+        searchable: true,
+        fulltext: "searchableTitle",
+      })
+      .addField({
+        field: "authorName",
+        type: "string",
+        replacement: "author.name",
+        filterable: true,
+        sortable: true,
+      })
+      .addField({
+        field: "publishedAt",
+        type: "date",
+        filterable: false,
+        sortable: true,
+      })
+      .build();
+
+    expect(result.BuilderBookEntityConnection).toBe(result.Connection);
+    expect(result.BuilderBookEntityConnectionArgs).toBe(result.ConnectionArgs);
+    expect(result.BuilderBookEntityEdge).toBe(result.Edge);
+    expect(result.BuilderBookEntityFilter).toBe(result.Filter);
+    expect(result.BuilderBookEntityOrder).toBe(result.Order);
+    expect(result.BuilderBookEntityOrderField).toBe(result.OrderField);
+    expect(result.OrderField).toEqual({
+      ID: "id",
+      TITLE: "title",
+      AUTHOR_NAME: "author.name",
+      PUBLISHED_AT: "publishedAt",
+    });
+
+    const metadata = Reflect.getMetadata(
+      GRAPHQL_CONNECTION_METADATA,
+      result.Connection,
+    ) as ConnectionMetadata<BuilderBook>;
+
+    expect(metadata.entityClass).toBe(BuilderBookEntity);
+    expect([...metadata.fieldOptionsMap.keys()]).toEqual([
+      "title",
+      "authorName",
+      "publishedAt",
+    ]);
+    expect(
+      result.filterQuerySchema.parse({
+        title: { $fulltext: "search term" },
+      }),
+    ).toEqual({
+      searchableTitle: { $fulltext: "search term" },
+    });
+    expect(
+      result.Filter.parseValue(JSON.stringify({ authorName: { $eq: "Ada" } })),
+    ).toEqual({
+      author: { name: { $eq: "Ada" } },
+    });
+    expect(
+      result.Filter.parseLiteral({
+        kind: Kind.OBJECT,
+        fields: [
+          {
+            kind: Kind.OBJECT_FIELD,
+            name: { kind: Kind.NAME, value: "title" },
+            value: {
+              kind: Kind.OBJECT,
+              fields: [
+                {
+                  kind: Kind.OBJECT_FIELD,
+                  name: { kind: Kind.NAME, value: "$eq" },
+                  value: { kind: Kind.STRING, value: "GraphQL" },
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    ).toEqual({
+      title: { $eq: "GraphQL" },
+    });
+
+    LazyMetadataStorage.load();
+    TypeMetadataStorage.compile();
+
+    expect(
+      fieldNamesAndInvokeTypeFns(
+        TypeMetadataStorage.getObjectTypeMetadataByTarget(result.Connection),
+      ),
+    ).toEqual(["edges", "pageInfo", "totalCount"]);
+    expect(
+      fieldNamesAndInvokeTypeFns(
+        TypeMetadataStorage.getObjectTypeMetadataByTarget(result.Edge),
+      ),
+    ).toEqual(["node", "cursor"]);
+    expect(
+      fieldNamesAndInvokeTypeFns(
+        TypeMetadataStorage.getObjectTypeMetadataByTarget(PageInfo),
+      ),
+    ).toEqual(["hasNextPage", "hasPreviousPage", "startCursor", "endCursor"]);
+    expect(
+      fieldNamesAndInvokeTypeFns(
+        TypeMetadataStorage.getArgumentsMetadataByTarget(result.ConnectionArgs),
+      ),
+    ).toEqual([
+      "query",
+      "filter",
+      "first",
+      "last",
+      "after",
+      "before",
+      "orderBy",
+    ]);
+    expect(
+      fieldNamesAndInvokeTypeFns(
+        TypeMetadataStorage.getInputTypeMetadataByTarget(result.Order),
+      ),
+    ).toEqual(["field", "direction"]);
+  });
+});

--- a/packages/graphql-connection/src/connection.builder.ts
+++ b/packages/graphql-connection/src/connection.builder.ts
@@ -1,12 +1,12 @@
 import type { EntityClass, FilterQuery } from "@mikro-orm/core";
 import { type Type } from "@nestjs/common";
 import { GraphQLScalarType } from "graphql";
-import type { FieldType } from "mikro-orm-filter-query-schema";
 import type { ZodType } from "zod";
 
 import {
   ConnectionArgsInterface,
   ConnectionBuilderOptions,
+  ConnectionFieldOptions,
   ConnectionInterface,
   EdgeInterface,
   FieldOptions,
@@ -111,7 +111,7 @@ export class ConnectionBuilder<Entity extends object> {
   /** Map of field names to their sort/filter options. @internal */
   private readonly fieldOptionsMap = new Map<
     string,
-    FieldOptions<Entity, FieldType, string>
+    ConnectionFieldOptions<Entity>
   >();
 
   /**
@@ -163,7 +163,7 @@ export class ConnectionBuilder<Entity extends object> {
   >(options: FieldOptions<Entity, Type, Field>): this {
     this.fieldOptionsMap.set(
       options.field,
-      options as FieldOptions<Entity, FieldType, string>,
+      options as ConnectionFieldOptions<Entity>,
     );
     return this;
   }

--- a/packages/graphql-connection/src/connection.manager.spec.ts
+++ b/packages/graphql-connection/src/connection.manager.spec.ts
@@ -1,0 +1,70 @@
+import "reflect-metadata";
+
+import type { EntityManager } from "@mikro-orm/core";
+
+import { ConnectionBuilder } from "./connection.builder";
+import { ConnectionManager } from "./connection.manager";
+
+interface ManagerBook {
+  id: number;
+  title: string;
+}
+
+class ManagerBookEntity implements ManagerBook {
+  id!: number;
+
+  title!: string;
+}
+
+describe("ConnectionManager", () => {
+  it("executes a connection query with additional find options", async () => {
+    const { Connection } = new ConnectionBuilder(ManagerBookEntity)
+      .addField({
+        field: "title",
+        type: "string",
+        filterable: true,
+        sortable: true,
+      })
+      .build();
+    const rows = [
+      { id: 1, title: "A" },
+      { id: 2, title: "B" },
+    ];
+    const find = jest.fn().mockResolvedValue(rows);
+    const findAll = jest.fn().mockResolvedValue(rows);
+    const entityManager = {
+      find,
+      findAll,
+    } as unknown as EntityManager;
+
+    const result = await new ConnectionManager(entityManager).find(
+      Connection,
+      {
+        first: 1,
+        filter: { title: { $eq: "A" } },
+      },
+      {
+        where: { id: { $gt: 0 } },
+        disableIdentityMap: true,
+      },
+    );
+
+    expect(find).toHaveBeenNthCalledWith(
+      1,
+      ManagerBookEntity,
+      {
+        $and: [{ id: { $gt: 0 } }, { title: { $eq: "A" } }],
+      },
+      expect.objectContaining({
+        disableIdentityMap: true,
+        limit: 2,
+        orderBy: [{ id: "ASC" }],
+        where: { id: { $gt: 0 } },
+      }),
+    );
+    expect(result.totalCount).toBe(2);
+    expect(result.edges).toHaveLength(1);
+    expect(result.pageInfo.hasNextPage).toBe(true);
+    expect(result.pageInfo.hasPreviousPage).toBe(false);
+  });
+});

--- a/packages/graphql-connection/src/cursor.spec.ts
+++ b/packages/graphql-connection/src/cursor.spec.ts
@@ -1,0 +1,19 @@
+import { Cursor } from "./cursor";
+
+describe("Cursor", () => {
+  it("encodes and decodes cursor payloads", () => {
+    const encoded = new Cursor({ id: "1", value: "title" }).toString();
+
+    const cursor = new Cursor(encoded);
+
+    expect(cursor.id).toBe("1");
+    expect(cursor.value).toBe("title");
+  });
+
+  it("ignores invalid cursor strings", () => {
+    const cursor = new Cursor("not-base64-json");
+
+    expect(cursor.id).toBeUndefined();
+    expect(cursor.toString()).toBe("e30=");
+  });
+});

--- a/packages/graphql-connection/src/graphql-connection.module.spec.ts
+++ b/packages/graphql-connection/src/graphql-connection.module.spec.ts
@@ -1,0 +1,23 @@
+import { GraphQLConnectionModule } from "./graphql-connection.module";
+
+describe("GraphQLConnectionModule", () => {
+  it("registers module options", () => {
+    const module = GraphQLConnectionModule.register({});
+
+    expect(module.module).toBe(GraphQLConnectionModule);
+    expect(module.providers).toEqual([
+      expect.objectContaining({
+        useValue: {},
+      }),
+    ]);
+  });
+
+  it("registers async options", () => {
+    const module = GraphQLConnectionModule.registerAsync({
+      useFactory: () => ({}),
+    });
+
+    expect(module.module).toBe(GraphQLConnectionModule);
+    expect(module.imports).toEqual([]);
+  });
+});

--- a/packages/graphql-connection/src/index.spec.ts
+++ b/packages/graphql-connection/src/index.spec.ts
@@ -1,0 +1,12 @@
+import * as publicApi from ".";
+
+describe("public exports", () => {
+  it("exports runtime connection APIs", () => {
+    expect(publicApi.ConnectionBuilder).toBeDefined();
+    expect(publicApi.ConnectionManager).toBeDefined();
+    expect(publicApi.GraphQLConnectionModule).toBeDefined();
+    expect(publicApi.OrderDirection).toBeDefined();
+    expect(publicApi.PageInfo).toBeDefined();
+    expect(publicApi.createFilter).toBeDefined();
+  });
+});

--- a/packages/graphql-connection/src/interfaces/connection-metadata.interface.ts
+++ b/packages/graphql-connection/src/interfaces/connection-metadata.interface.ts
@@ -1,8 +1,7 @@
 import { EntityClass, FilterQuery } from "@mikro-orm/core";
-import type { FieldType } from "mikro-orm-filter-query-schema";
 import type { ZodType } from "zod";
 
-import { FieldOptions } from "../types/field-options.type";
+import { ConnectionFieldOptions } from "../types/field-options.type";
 
 /**
  * Metadata stored on connection classes for query building.
@@ -23,7 +22,7 @@ export interface ConnectionMetadata<Entity extends object> {
   /**
    * Map of field names to their configuration options.
    */
-  fieldOptionsMap: Map<string, FieldOptions<Entity, FieldType, string>>;
+  fieldOptionsMap: Map<string, ConnectionFieldOptions<Entity>>;
 
   /**
    * Zod schema for validating and parsing filter queries.

--- a/packages/graphql-connection/src/types/field-options.type.ts
+++ b/packages/graphql-connection/src/types/field-options.type.ts
@@ -1,5 +1,7 @@
+import type { FilterQuery } from "@mikro-orm/core";
 import type {
   FieldType,
+  ReplacementCallbackArgs,
   ReplacementCallbackFieldOptions as FilterReplacementCallbackFieldOptions,
   ReplacementFieldOptions as FilterReplacementFieldOptions,
   SimpleFieldOptions as FilterSimpleFieldOptions,
@@ -18,6 +20,9 @@ export interface BaseFieldOptions {
   /**
    * Whether this field is included in text search queries.
    * Only applicable to string fields.
+   *
+   * When combined with `fulltext: "fieldPath"`, search queries use
+   * `$fulltext` on the configured full-text field path.
    */
   searchable?: boolean;
 }
@@ -42,7 +47,8 @@ export interface SortableFieldOptions {
 export type SimpleFieldOptions<
   Entity extends object,
   Type extends FieldType = never,
-> = FilterSimpleFieldOptions<Entity, Type> &
+  Field extends string = never,
+> = FilterSimpleFieldOptions<Entity, Type, Field> &
   BaseFieldOptions &
   SortableFieldOptions;
 
@@ -74,7 +80,8 @@ export type ReplacementFieldOptions<
 export type ReplacementFunctionFieldOptions<
   Entity extends object,
   Type extends FieldType = never,
-> = FilterReplacementCallbackFieldOptions<Entity, Type> &
+  Field extends string = never,
+> = FilterReplacementCallbackFieldOptions<Entity, Type, Field> &
   BaseFieldOptions &
   SortableFieldOptions;
 
@@ -112,6 +119,49 @@ export type FieldOptions<
   Type extends FieldType = never,
   Field extends string = never,
 > =
-  | SimpleFieldOptions<Entity, Type>
+  | SimpleFieldOptions<Entity, Type, Field>
   | ReplacementFieldOptions<Entity, Type, Field>
-  | ReplacementFunctionFieldOptions<Entity, Type>;
+  | ReplacementFunctionFieldOptions<Entity, Type, Field>;
+
+/**
+ * Runtime field configuration stored after a field has been added.
+ *
+ * This intentionally avoids the public AutoPath-heavy field option types so
+ * internal maps can be passed around without repeatedly expanding entity paths.
+ *
+ * @typeParam Entity - The entity type
+ */
+export type ConnectionFieldOptions<Entity extends object> = BaseFieldOptions &
+  SortableFieldOptions & {
+    /**
+     * The field name used in connection filter and search input.
+     */
+    field: string;
+
+    /**
+     * The field data type.
+     */
+    type: FieldType;
+
+    /**
+     * Whether this field represents an array type.
+     */
+    array?: boolean;
+
+    /**
+     * Enables `$fulltext`; when set to a string path, maps `$fulltext` there.
+     */
+    fulltext?: boolean | string;
+
+    /**
+     * Enables `$prefix` for string prefix searches.
+     */
+    prefix?: boolean;
+
+    /**
+     * Optional field replacement path or callback.
+     */
+    replacement?:
+      | string
+      | ((args: ReplacementCallbackArgs<FieldType>) => FilterQuery<Entity>);
+  };

--- a/packages/graphql-connection/src/utils/create-connection-args.ts
+++ b/packages/graphql-connection/src/utils/create-connection-args.ts
@@ -3,11 +3,10 @@ import { ArgsType, Field, Int } from "@nest-boot/graphql";
 import { type Type } from "@nestjs/common";
 import { GraphQLScalarType } from "graphql";
 import { humanize, pluralize } from "inflection";
-import type { FieldType } from "mikro-orm-filter-query-schema";
 
 import {
   ConnectionArgsInterface,
-  FieldOptions,
+  ConnectionFieldOptions,
   OrderInterface,
 } from "../interfaces";
 
@@ -32,7 +31,7 @@ import {
  */
 export function createConnectionArgs<Entity extends object>(
   entityName: string,
-  fieldOptionsMap: Map<string, FieldOptions<Entity, FieldType, string>>,
+  fieldOptionsMap: Map<string, ConnectionFieldOptions<Entity>>,
   OrderClass: Type<OrderInterface<Entity>>,
   FilterScalar: GraphQLScalarType<FilterQuery<Entity>>,
 ): Type<ConnectionArgsInterface<Entity>> {

--- a/packages/graphql-connection/src/utils/create-connection.ts
+++ b/packages/graphql-connection/src/utils/create-connection.ts
@@ -2,15 +2,14 @@ import type { EntityClass, FilterQuery } from "@mikro-orm/core";
 import { Field, Int, ObjectType } from "@nest-boot/graphql";
 import { type Type } from "@nestjs/common";
 import { pluralize } from "inflection";
-import type { FieldType } from "mikro-orm-filter-query-schema";
 import type { ZodType } from "zod";
 
 import { GRAPHQL_CONNECTION_METADATA } from "../graphql-connection.constants";
 import {
+  ConnectionFieldOptions,
   ConnectionInterface,
   ConnectionMetadata,
   EdgeInterface,
-  FieldOptions,
 } from "../interfaces";
 import { PageInfo } from "../objects";
 
@@ -36,7 +35,7 @@ export function createConnection<Entity extends object>(
   entityClass: EntityClass<Entity>,
   entityName: string,
   EdgeClass: Type<EdgeInterface<Entity>>,
-  fieldOptionsMap: Map<string, FieldOptions<Entity, FieldType, string>>,
+  fieldOptionsMap: Map<string, ConnectionFieldOptions<Entity>>,
   filterQuerySchema: ZodType<FilterQuery<Entity>>,
 ): Type<ConnectionInterface<Entity>> {
   const pluralizeEntityName = pluralize(entityName);

--- a/packages/graphql-connection/src/utils/create-filter.spec.ts
+++ b/packages/graphql-connection/src/utils/create-filter.spec.ts
@@ -1,9 +1,13 @@
+import { Kind } from "graphql";
+
 import type { ConnectionFieldOptions, FieldOptions } from "../interfaces";
 import { createFilter } from "./create-filter";
 
 interface Book {
   title: string;
   searchableTitle: string;
+  rating: number;
+  published: boolean;
 }
 
 describe("createFilter", () => {
@@ -45,6 +49,125 @@ describe("createFilter", () => {
     ).toEqual({
       title: { $eq: "exact title" },
       searchableTitle: { $fulltext: "search term" },
+    });
+  });
+
+  it("parses scalar values from GraphQL literals", () => {
+    const fieldOptionsMap = new Map<string, ConnectionFieldOptions<Book>>([
+      ["title", { field: "title", type: "string" }],
+      ["rating", { field: "rating", type: "number" }],
+      ["published", { field: "published", type: "boolean" }],
+    ]);
+
+    const { Filter } = createFilter("BookLiteral", fieldOptionsMap);
+
+    expect(
+      Filter.parseLiteral({
+        kind: Kind.OBJECT,
+        fields: [
+          {
+            kind: Kind.OBJECT_FIELD,
+            name: { kind: Kind.NAME, value: "title" },
+            value: {
+              kind: Kind.OBJECT,
+              fields: [
+                {
+                  kind: Kind.OBJECT_FIELD,
+                  name: { kind: Kind.NAME, value: "$in" },
+                  value: {
+                    kind: Kind.LIST,
+                    values: [
+                      { kind: Kind.STRING, value: "A" },
+                      { kind: Kind.ENUM, value: "B" },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+          {
+            kind: Kind.OBJECT_FIELD,
+            name: { kind: Kind.NAME, value: "rating" },
+            value: {
+              kind: Kind.OBJECT,
+              fields: [
+                {
+                  kind: Kind.OBJECT_FIELD,
+                  name: { kind: Kind.NAME, value: "$gte" },
+                  value: { kind: Kind.FLOAT, value: "4.5" },
+                },
+                {
+                  kind: Kind.OBJECT_FIELD,
+                  name: { kind: Kind.NAME, value: "$lte" },
+                  value: { kind: Kind.INT, value: "5" },
+                },
+              ],
+            },
+          },
+          {
+            kind: Kind.OBJECT_FIELD,
+            name: { kind: Kind.NAME, value: "published" },
+            value: {
+              kind: Kind.OBJECT,
+              fields: [
+                {
+                  kind: Kind.OBJECT_FIELD,
+                  name: { kind: Kind.NAME, value: "$eq" },
+                  value: { kind: Kind.BOOLEAN, value: true },
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    ).toEqual({
+      title: { $in: ["A", "B"] },
+      rating: { $gte: 4.5, $lte: 5 },
+      published: { $eq: true },
+    });
+  });
+
+  it("reports invalid filter values", () => {
+    const fieldOptionsMap = new Map<string, ConnectionFieldOptions<Book>>([
+      ["title", { field: "title", type: "string" }],
+    ]);
+
+    const { Filter } = createFilter("BookInvalid", fieldOptionsMap);
+
+    expect(() => Filter.parseValue("{")).toThrow(
+      "Filter must be a valid JSON string",
+    );
+    expect(
+      Filter.parseLiteral({
+        kind: Kind.OBJECT,
+        fields: [
+          {
+            kind: Kind.OBJECT_FIELD,
+            name: { kind: Kind.NAME, value: "title" },
+            value: {
+              kind: Kind.OBJECT,
+              fields: [
+                {
+                  kind: Kind.OBJECT_FIELD,
+                  name: { kind: Kind.NAME, value: "$eq" },
+                  value: { kind: Kind.NULL },
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    ).toEqual({
+      title: { $eq: null },
+    });
+    expect(() =>
+      Filter.parseLiteral({
+        kind: Kind.VARIABLE,
+        name: { kind: Kind.NAME, value: "filter" },
+      }),
+    ).toThrow("Unexpected AST kind: Variable");
+    expect(Filter.serialize({ title: { $eq: "GraphQL" } })).toEqual({
+      title: { $eq: "GraphQL" },
     });
   });
 });

--- a/packages/graphql-connection/src/utils/create-filter.spec.ts
+++ b/packages/graphql-connection/src/utils/create-filter.spec.ts
@@ -1,0 +1,50 @@
+import type { ConnectionFieldOptions, FieldOptions } from "../interfaces";
+import { createFilter } from "./create-filter";
+
+interface Book {
+  title: string;
+  searchableTitle: string;
+}
+
+describe("createFilter", () => {
+  it("maps $fulltext to a configured fulltext field path", () => {
+    const titleField = {
+      field: "title",
+      type: "string",
+      fulltext: "searchableTitle",
+    } satisfies FieldOptions<Book, "string", "searchableTitle">;
+    const fieldOptionsMap = new Map<string, ConnectionFieldOptions<Book>>([
+      ["title", titleField],
+    ]);
+
+    const { filterQuerySchema } = createFilter("Book", fieldOptionsMap);
+
+    expect(
+      filterQuerySchema.parse({ title: { $fulltext: "search term" } }),
+    ).toEqual({
+      searchableTitle: { $fulltext: "search term" },
+    });
+  });
+
+  it("keeps non-fulltext operators on the original field", () => {
+    const titleField = {
+      field: "title",
+      type: "string",
+      fulltext: "searchableTitle",
+    } satisfies FieldOptions<Book, "string", "searchableTitle">;
+    const fieldOptionsMap = new Map<string, ConnectionFieldOptions<Book>>([
+      ["title", titleField],
+    ]);
+
+    const { filterQuerySchema } = createFilter("Book", fieldOptionsMap);
+
+    expect(
+      filterQuerySchema.parse({
+        title: { $eq: "exact title", $fulltext: "search term" },
+      }),
+    ).toEqual({
+      title: { $eq: "exact title" },
+      searchableTitle: { $fulltext: "search term" },
+    });
+  });
+});

--- a/packages/graphql-connection/src/utils/create-filter.ts
+++ b/packages/graphql-connection/src/utils/create-filter.ts
@@ -7,7 +7,7 @@ import {
   FilterQuerySchemaBuilder,
 } from "mikro-orm-filter-query-schema";
 
-import { FieldOptions } from "../interfaces";
+import { ConnectionFieldOptions } from "../interfaces";
 
 /**
  * The Zod schema type returned by FilterQuerySchemaBuilder.
@@ -89,7 +89,7 @@ export interface CreateFilterResult<Entity extends object> {
  */
 export function createFilter<Entity extends object>(
   entityName: string,
-  fieldOptionsMap: Map<string, FieldOptions<Entity, FieldType, string>>,
+  fieldOptionsMap: Map<string, ConnectionFieldOptions<Entity>>,
   filterOptions?: FilterOptions,
 ): CreateFilterResult<Entity> {
   const filterableFields = [...fieldOptionsMap.values()]
@@ -101,7 +101,7 @@ export function createFilter<Entity extends object>(
   for (const [, options] of fieldOptionsMap) {
     if (options.filterable !== false) {
       builder.addField(
-        options as FilterFieldOptions<Entity, FieldType, string>,
+        options as unknown as FilterFieldOptions<Entity, FieldType, string>,
       );
     }
   }

--- a/packages/graphql-connection/src/utils/create-order.ts
+++ b/packages/graphql-connection/src/utils/create-order.ts
@@ -1,11 +1,10 @@
 import { Field, InputType, registerEnumType } from "@nest-boot/graphql";
 import { type Type } from "@nestjs/common";
 import { humanize, pluralize, underscore } from "inflection";
-import type { FieldType } from "mikro-orm-filter-query-schema";
 
 import { OrderDirection } from "../enums";
 import {
-  FieldOptions,
+  ConnectionFieldOptions,
   OrderFieldKey,
   OrderFieldType,
   OrderInterface,
@@ -47,7 +46,7 @@ export interface CreateOrderResult<Entity extends object> {
  */
 export function createOrder<Entity extends object>(
   entityName: string,
-  fieldOptionsMap: Map<string, FieldOptions<Entity, FieldType, string>>,
+  fieldOptionsMap: Map<string, ConnectionFieldOptions<Entity>>,
 ): CreateOrderResult<Entity> {
   const humanizeEntityName = humanize(entityName, true);
   const humanizeAndPluralizeEntityName = pluralize(humanize(entityName, true));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.2.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -644,14 +644,14 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       mikro-orm-filter-query-schema:
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^1.3.0
+        version: 1.3.0
       search-syntax:
         specifier: ^3.7.0
         version: 3.7.0
       zod:
-        specifier: ^4.1.13
-        version: 4.2.1
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@mikro-orm/core':
         specifier: ^6.6.2
@@ -7140,8 +7140,8 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
-  mikro-orm-filter-query-schema@1.2.0:
-    resolution: {integrity: sha512-O9fDhfuWQQhqS4PkPoI8+8XwvlkeEeeqK+b/Z1k06p0X0GH1+zbm9PY+kBBLptPVk8a4UpnqiNet88g4PQ/Scg==}
+  mikro-orm-filter-query-schema@1.3.0:
+    resolution: {integrity: sha512-GaACgEVTvG2DcAbQwJY/moTT2/3aHiX5t/7Pmeoa2FNn1D3BSGvzlliWPYPn+vD0Ki9ibZCKt/l7B1BsofZ+1g==}
 
   mikro-orm@6.6.2:
     resolution: {integrity: sha512-fCPwQZVIfOeQZecBYmJy+21zSrWTlt/thUNONjTtcBHzQNu3f+zVGY0kn9gs6x6bvT570cNlPLmzHVd3NCM4Kw==}
@@ -8737,9 +8737,6 @@ packages:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
     engines: {node: '>=18.0.0'}
 
-  zod@4.2.1:
-    resolution: {integrity: sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==}
-
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
@@ -10333,7 +10330,7 @@ snapshots:
   '@better-auth/core@1.4.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
-      zod: 4.2.1
+      zod: 4.3.6
 
   '@better-auth/telemetry@1.4.10':
     dependencies:
@@ -12981,7 +12978,7 @@ snapshots:
       jose: 6.1.0
       kysely: 0.28.8
       nanostores: 1.0.1
-      zod: 4.2.1
+      zod: 4.3.6
 
   better-call@1.1.7:
     dependencies:
@@ -16057,9 +16054,9 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
-  mikro-orm-filter-query-schema@1.2.0:
+  mikro-orm-filter-query-schema@1.3.0:
     dependencies:
-      zod: 4.2.1
+      zod: 4.3.6
 
   mikro-orm@6.6.2: {}
 
@@ -18016,8 +18013,6 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod-validation-error@4.0.2: {}
-
-  zod@4.2.1: {}
 
   zod@4.3.6: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  zod: 4.3.6
+
 packageExtensionsChecksum: sha256-B0uJqCz4aIbwUOzF3ujbtRFJ8Y7J+jgRCi6kihMS6gk=
 
 pnpmfileChecksum: sha256-awLY/INtdu5iPZU3oN/s1ayurtSxg/S8WQkdOOoHKXk=
@@ -72,6 +75,9 @@ importers:
       typedoc-plugin-markdown:
         specifier: ^4.10.0
         version: 4.10.0
+      zod:
+        specifier: 4.3.6
+        version: 4.3.6
 
   apps/docs:
     dependencies:
@@ -103,7 +109,7 @@ importers:
         specifier: ^3.5.0
         version: 3.5.0
       zod:
-        specifier: ^4.3.6
+        specifier: 4.3.6
         version: 4.3.6
     devDependencies:
       '@tailwindcss/postcss':
@@ -653,7 +659,7 @@ importers:
         specifier: ^3.7.0
         version: 3.7.0
       zod:
-        specifier: ^4.3.6
+        specifier: 4.3.6
         version: 4.3.6
     devDependencies:
       '@mikro-orm/core':


### PR DESCRIPTION
## Summary

- Upgrade `@nest-boot/graphql-connection` to `mikro-orm-filter-query-schema@^1.3.0` and align `zod`.
- Allow `fulltext: "fieldPath"` field options to flow through GraphQL connection filters.
- Convert string fulltext mappings to `fulltext: true` for `search-syntax`, then let `filterQuerySchema.parse(...)` map `$fulltext` to the configured field path.
- Add coverage for both scalar filter input and `query` string parsing.
- Document dedicated MikroORM full-text field mapping in English and Chinese docs.

## Validation

- `pnpm --filter @nest-boot/graphql-connection build`
- `pnpm --filter @nest-boot/graphql-connection lint`
- `pnpm exec jest --config packages/graphql-connection/jest.config.ts --runInBand`
- `pnpm exec prettier --check apps/docs/content/docs/tutorial/graphql-connection.mdx apps/docs/content/docs/tutorial/graphql-connection.zh-Hans.mdx packages/graphql-connection/src/connection-query-builder.spec.ts packages/graphql-connection/src/utils/create-filter.spec.ts packages/graphql-connection/src/types/field-options.type.ts packages/graphql-connection/src/connection-query-builder.ts packages/graphql-connection/jest.config.ts`
- `git diff --check`
- Commit hook: `pnpm docs:check` (runs package builds and typedoc check)