### PR TITLE
fix: update filter query schema dependency

### DIFF
--- a/packages/graphql-connection/package.json
+++ b/packages/graphql-connection/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "inflection": "^3.0.2",
     "lodash": "^4.17.21",
-    "mikro-orm-filter-query-schema": "^1.3.0",
+    "mikro-orm-filter-query-schema": "^1.4.0",
     "search-syntax": "^3.7.0",
     "zod": "^4.3.6"
   },

--- a/packages/graphql-connection/src/utils/create-filter.spec.ts
+++ b/packages/graphql-connection/src/utils/create-filter.spec.ts
@@ -52,6 +52,18 @@ describe("createFilter", () => {
     });
   });
 
+  it("transforms $between filters through the filter query schema", () => {
+    const fieldOptionsMap = new Map<string, ConnectionFieldOptions<Book>>([
+      ["rating", { field: "rating", type: "number" }],
+    ]);
+
+    const { filterQuerySchema } = createFilter("BookBetween", fieldOptionsMap);
+
+    expect(filterQuerySchema.parse({ rating: { $between: [3, 5] } })).toEqual({
+      rating: { $gte: 3, $lte: 5 },
+    });
+  });
+
   it("parses scalar values from GraphQL literals", () => {
     const fieldOptionsMap = new Map<string, ConnectionFieldOptions<Book>>([
       ["title", { field: "title", type: "string" }],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -653,8 +653,8 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       mikro-orm-filter-query-schema:
-        specifier: ^1.3.0
-        version: 1.3.0
+        specifier: ^1.4.0
+        version: 1.4.0
       search-syntax:
         specifier: ^3.7.0
         version: 3.7.0
@@ -7149,8 +7149,8 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
-  mikro-orm-filter-query-schema@1.3.0:
-    resolution: {integrity: sha512-GaACgEVTvG2DcAbQwJY/moTT2/3aHiX5t/7Pmeoa2FNn1D3BSGvzlliWPYPn+vD0Ki9ibZCKt/l7B1BsofZ+1g==}
+  mikro-orm-filter-query-schema@1.4.0:
+    resolution: {integrity: sha512-1TnsQwEqB9qfifb7yChkIscAMoGbcH2DCdruYtGKJU9QxTrZRdYz+jDl4mgkvYkokFf+iQCjK5lipjqFaSdIyw==}
 
   mikro-orm@6.6.2:
     resolution: {integrity: sha512-fCPwQZVIfOeQZecBYmJy+21zSrWTlt/thUNONjTtcBHzQNu3f+zVGY0kn9gs6x6bvT570cNlPLmzHVd3NCM4Kw==}
@@ -16063,7 +16063,7 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
-  mikro-orm-filter-query-schema@1.3.0:
+  mikro-orm-filter-query-schema@1.4.0:
     dependencies:
       zod: 4.3.6
 


### PR DESCRIPTION
## Summary

- update `@nest-boot/graphql-connection` to use `mikro-orm-filter-query-schema@^1.4.0`
- refresh the pnpm lockfile to resolve `mikro-orm-filter-query-schema@1.4.0`
- add a graphql-connection filter test covering `$between` expansion to `$gte`/`$lte`

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @nest-boot/graphql-connection build`
- `pnpm --filter @nest-boot/graphql-connection lint`
- `pnpm exec jest --config packages/graphql-connection/jest.config.ts --runInBand`
- commit hook: `lint-staged && pnpm docs:check`
